### PR TITLE
Fix Ruby client generator

### DIFF
--- a/rest-gen/rest-gen.cabal
+++ b/rest-gen/rest-gen.cabal
@@ -72,6 +72,7 @@ library
     , uniplate >= 1.6.12 && < 1.7
     , unordered-containers == 0.2.*
     , vector == 0.10.*
+    , MissingH >= 1.2.1.0
 
 test-suite rest-gen-tests
   hs-source-dirs:    tests

--- a/rest-gen/src/Rest/Gen/Ruby.hs
+++ b/rest-gen/src/Rest/Gen/Ruby.hs
@@ -3,6 +3,7 @@ module Rest.Gen.Ruby (mkRbApi) where
 
 import Data.Char
 import Data.List
+import Data.List.Utils (replace)
 import Data.Maybe
 
 import Code.Build
@@ -17,9 +18,10 @@ import Rest.Gen.Utils
 
 mkRbApi :: H.ModuleName -> Bool -> Version -> Router m s -> IO String
 mkRbApi ns priv ver r =
-  do prelude <- readContent "Ruby/base.rb"
+  do rawPrelude <- readContent "Ruby/base.rb"
+     let prelude = replace "SilkApi" (unModuleName ns) rawPrelude
      let cod = showCode . mkRb (unModuleName ns) ver . sortTree . (if priv then id else noPrivate) . apiSubtrees $ r
-     return $ cod ++ prelude
+     return $ cod ++ "\n" ++ prelude
 
 mkRb :: String -> Version -> ApiResource -> Code
 mkRb ns ver node =


### PR DESCRIPTION
I'm not very familiar with Haskell, so the code might be not quite perfect, feel free to comment.

I added the MissingH dependency, because it contains a useful function `replace` in `Data.List.Utils` module. If anybody knows how to replace a substring without adding extra dependency - let me know.

I tested the generated client - it works, so this pull request fixes issues mentioned in https://github.com/silkapp/rest/issues/36 .

```
$ cabal run rest-example-gen -- --ruby > client.rb

$ ruby -r ./client.rb -e "p RestexampleApi::Api.new('http://localhost:3000').Post.list"

Fix url encoding when this is going to be used[{"offset"=>0, "count"=>2, "items"=>[{"createdTime"=>"2014-04-01T13:37:00.000Z", "content"=>"Just wanted to tell the world!", "author"=>"erik", "id"=>1, "title"=>"Rest is awesome"}, {"createdTime"=>"2014-03-31T15:34:00.000Z", "content"=>"Hello world!", "author"=>"adam", "id"=>0, "title"=>"First post"}]}, #<Net::HTTPOK 200 OK readbody=true>]
```
