### PR TITLE
Refactored `trim` function to get rid of some duplication

### DIFF
--- a/rest-core/src/Rest/Driver/Perform.hs
+++ b/rest-core/src/Rest/Driver/Perform.hs
@@ -373,7 +373,8 @@ accept =
         [ ["image"]       , xs    ] -> xs >>= img
         _                           -> []
 
-    trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace
+    trim = f . f
+      where f = reverse . dropWhile isSpace
 
     txt "*"     = [XmlFormat, JsonFormat, StringFormat]
     txt "json"  = [JsonFormat]


### PR DESCRIPTION
<pre> 
  trim = f . f
    where f = reverse . dropWhile isSpace
</pre> 

<b> looks better than </b> 

<pre> 
trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace 
</pre> 
