### PR TITLE
Implement multipartI modifier

### DIFF
--- a/rest-core/src/Rest/Dictionary/Combinators.hs
+++ b/rest-core/src/Rest/Dictionary/Combinators.hs
@@ -17,6 +17,7 @@ module Rest.Dictionary.Combinators
   , xmlI
   , rawXmlI
   , jsonI
+  , multipartI
 
   -- ** Output dictionaries
 
@@ -112,6 +113,11 @@ xmlTextI = L.set inputs (Dicts [XmlTextI])
 
 fileI :: Dict h p Nothing o e -> Dict h p (Just ByteString) o e
 fileI = L.set inputs (Dicts [FileI])
+
+-- | Allow generic mixed input, represented as [BodyPart].
+
+multipartI :: Dict h p i o e -> Dict h p [BodyPart] o e
+multipartI = L.set inputs (Dicts [MultipartI]) 
 
 -- | The input can be read into some instance of `Read`. For inspection reasons
 -- the type must also be an instance of both `Info` and `Show`.

--- a/rest-core/src/Rest/Dictionary/Types.hs
+++ b/rest-core/src/Rest/Dictionary/Types.hs
@@ -77,9 +77,9 @@ data Format
   | JsonFormat
   | StringFormat
   | FileFormat
-  | MultipartFormat
+  | MultipartFormat String
   | NoFormat
-  deriving (Eq, Ord, Enum, Bounded, Show)
+  deriving (Eq, Ord, Show)
 
 -- | The explicit dictionary `Ident` describes how to translate a resource
 -- identifier (originating from a request URI) to a Haskell value. We allow
@@ -140,13 +140,14 @@ instance Show (Param p) where
 -- needs of the backend resource.
 
 data Input i where
-  JsonI    :: (Typeable i, FromJSON i, JSONSchema i) => Input i
-  ReadI    :: (Info i, Read i, Show i)               => Input i
-  StringI  ::                                           Input String
-  FileI    ::                                           Input ByteString
-  XmlI     :: (Typeable i, XmlPickler i)             => Input i
-  XmlTextI ::                                           Input Text
-  RawXmlI  ::                                           Input ByteString
+  JsonI      :: (Typeable i, FromJSON i, JSONSchema i) => Input i
+  ReadI      :: (Info i, Read i, Show i)               => Input i
+  StringI    ::                                           Input String
+  FileI      ::                                           Input ByteString
+  MultipartI ::                                           Input [BodyPart]
+  XmlI       :: (Typeable i, XmlPickler i)             => Input i
+  XmlTextI   ::                                           Input Text
+  RawXmlI    ::                                           Input ByteString
 
 deriving instance Show (Input i)
 deriving instance Eq   (Input i)

--- a/rest-core/src/Rest/Dictionary/Types.hs
+++ b/rest-core/src/Rest/Dictionary/Types.hs
@@ -112,8 +112,8 @@ instance Show (Header h) where
                                                    . showsPrec 10 k
                                                    )
 
--- | The explicit dictionary `Parameter` describes how to translate the request
--- parameters to some Haskell value. The first field in the `Header`
+-- | The explicit dictionary `Param` describes how to translate the request
+-- parameters to some Haskell value. The first field in the `Param`
 -- constructor is a white list of paramters we can recognize, used in generic
 -- validation and for generating documentation. The second field is a custom
 -- parser that can fail with a `DataError` or can produce a some value. When


### PR DESCRIPTION
This branch implements multipart input to go along with the multipart output combinator.  I have tested it with curl and it seems to work fine.  There also looks to be no impact on my json GET/POST resources, so I don't think it breaks anything.  I did not test or assess the impact on rest-gen for docs/clients.

I have the following concerns about my implementation.  Not sure how problematic they might be.
- The multipart boundary is carried around in the MultipartFormat data contructor.  This makes Format no longer an Enum or a Bounded.  
- The BodyPart type is not re-exported from Rest.Dictionary.Combinators, so using mutlipartI requires importing Network.Multipart to get access to the type.  I don't know what the usual practice is for this kind of thing, so I left it alone.
- In this implementation, the body parts are all read as bytestrings and it is up to the handler to inspect headers in the BodyParts and parse the bytestrings as appropriate.  This requires either very complicated handling code or some kind of convention on the endpoint for significance and order of BodyParts (for instance, in my test code I check the number of body parts and throw UnsupportedFormat if the number is wrong).  I suspect there might be a smarter design that puts the header inspection/parsing into the backend code and out of the handler.

Thanks!  I am really loving the rest library.
