### PR TITLE
Added support for writing static response headers to HTTP actions.

### DIFF
--- a/rest-core/src/Rest.hs
+++ b/rest-core/src/Rest.hs
@@ -18,7 +18,7 @@ module Rest
 
 import Rest.Dictionary.Combinators
 import Rest.Error
-import Rest.Handler ( Env (..), Handler, ListHandler, secureHandler
+import Rest.Handler ( Env (..), Handler, ListHandler, secureHandler, setResponseHeaders, addResponseHeaders
                     , Range (..), range, mkListing, mkOrderedListing, mkHandler
                     , mkInputHandler, mkConstHandler, mkIdHandler
                     )

--- a/rest-core/src/Rest/Driver/Perform.hs
+++ b/rest-core/src/Rest/Driver/Perform.hs
@@ -132,9 +132,10 @@ instance Rest m => Rest (MaybeT m) where
   setResponseCode = lift . setResponseCode
 
 writeResponse :: Rest m => RunnableHandler m -> m UTF8.ByteString
-writeResponse (RunnableHandler run (GenHandler dict act _)) = do
+writeResponse (RunnableHandler run (GenHandler dict act _ rh)) = do
   res <- runErrorT $ do
     let os = L.get D.outputs dict
+    mapM_ (uncurry setHeader) rh
     validator os
     inp <- fetchInputs dict
     output <- mapErrorT run (act inp)

--- a/rest-core/src/Rest/Driver/Routing.hs
+++ b/rest-core/src/Rest/Driver/Routing.hs
@@ -293,9 +293,9 @@ guardMethod :: (MonadPlus m, MonadReader Method m) => Method -> m ()
 guardMethod method = ask >>= guard . (== method)
 
 mkListHandler :: Monad m => ListHandler m -> Maybe (Handler m)
-mkListHandler (GenHandler dict act sec) =
+mkListHandler (GenHandler dict act sec resH) =
   do newDict <- L.traverse outputs listO . addPar range $ dict
-     return $ GenHandler newDict (mkListAction act) sec
+     return $ GenHandler newDict (mkListAction act) sec resH
 
 mkListAction :: Monad m
             => (Env h p i -> ErrorT (Reason e) m [a])
@@ -306,7 +306,7 @@ mkListAction act (Env h (Range f c, p) i) = do
   return (List f (min c (length xs)) (take c xs))
 
 mkMultiHandler :: Monad m => Rest.Id id -> (id -> Run s m) -> Handler s -> Maybe (Handler m)
-mkMultiHandler sBy run (GenHandler dict act sec) = GenHandler <$> mNewDict <*> pure newAct <*> pure sec
+mkMultiHandler sBy run (GenHandler dict act sec resH) = GenHandler <$> mNewDict <*> pure newAct <*> pure sec <*> pure resH
   where
     newErrDict = L.modify errors reasonE dict
     mNewDict =  L.traverse inputs mappingI

--- a/rest-core/src/Rest/Handler.hs
+++ b/rest-core/src/Rest/Handler.hs
@@ -25,6 +25,8 @@ module Rest.Handler
 
     -- * Convenience functions.
   , secureHandler
+  , setResponseHeaders
+  , addResponseHeaders
   ) where
 
 import Control.Arrow
@@ -65,13 +67,14 @@ data GenHandler m f where
     { dictionary :: Dict h p i o e
     , handler    :: Env h p i -> ErrorT (Reason e) m (Apply f o)
     , secure     :: Bool
+    , resHeaders :: [(String, String)]
     } -> GenHandler m f
 
 -- | Construct a 'GenHandler' using a 'Modifier' instead of a 'Dict'.
 -- The 'secure' flag will be 'False'.
 
 mkGenHandler :: Monad m => Modifier h p i o e -> (Env h p i -> ErrorT (Reason e) m (Apply f o)) -> GenHandler m f
-mkGenHandler d a = GenHandler (d empty) a False
+mkGenHandler d a = GenHandler (d empty) a False []
 
 -- | Apply a Functor @f@ to a type @a@. In general will result in @f
 -- a@, except if @f@ is 'Identity', in which case it will result in
@@ -90,6 +93,16 @@ type ListHandler m = GenHandler m []
 
 secureHandler :: Handler m -> Handler m
 secureHandler h = h { secure = True }
+
+-- | Set default response headers for handler.
+
+setResponseHeaders :: [(String, String)] -> Handler m -> Handler m
+setResponseHeaders rh h = h { resHeaders = rh }
+
+-- | Add default response headers for handler.
+
+addResponseHeaders :: [(String, String)] -> Handler m -> Handler m
+addResponseHeaders rh h = h { resHeaders = rh ++ resHeaders h }
 
 -- | Data type for representing the requested range in list handlers.
 

--- a/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
+++ b/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
@@ -407,7 +407,7 @@ handlerActionInfo mId postAct actType actTarget pth mth ac h = ActionInfo
 -- * Utilities for extraction information from Handlers.
 
 handlerParams :: GenHandler m f -> [String]
-handlerParams (GenHandler dict _ _) = paramNames (L.get Dict.params dict)
+handlerParams (GenHandler dict _ _ _) = paramNames (L.get Dict.params dict)
 
 -- | A `Param` can contain the same parameter multiple times. For
 -- example, 'offset' and 'count' are added in Rest.Handler.mkListing,
@@ -424,7 +424,7 @@ paramNames_ (TwoParams p1 p2) = paramNames p1 ++ paramNames p2
 
 -- | Extract input description from handlers
 handlerInputs :: Handler m -> [DataDescription]
-handlerInputs (GenHandler dict _ _) = map (handlerInput Proxy) (L.get (Dict.dicts . Dict.inputs) dict)
+handlerInputs (GenHandler dict _ _ _) = map (handlerInput Proxy) (L.get (Dict.dicts . Dict.inputs) dict)
   where
     handlerInput :: Proxy a -> Input a -> DataDescription
     handlerInput d c = case c of
@@ -444,7 +444,7 @@ handlerInputs (GenHandler dict _ _) = map (handlerInput Proxy) (L.get (Dict.dict
 
 -- | Extract output description from handlers
 handlerOutputs :: Handler m -> [DataDescription]
-handlerOutputs (GenHandler dict _ _) = map (handlerOutput Proxy) (L.get (Dict.dicts . Dict.outputs) dict)
+handlerOutputs (GenHandler dict _ _ _) = map (handlerOutput Proxy) (L.get (Dict.dicts . Dict.outputs) dict)
   where
     handlerOutput :: Proxy a -> Output a -> DataDescription
     handlerOutput d c = case c of
@@ -461,7 +461,7 @@ handlerOutputs (GenHandler dict _ _) = map (handlerOutput Proxy) (L.get (Dict.di
 
 -- | Extract input description from handlers
 handlerErrors :: Handler m -> [DataDescription]
-handlerErrors (GenHandler dict _ _) = map (handleError Proxy) (L.get (Dict.dicts . Dict.errors) dict)
+handlerErrors (GenHandler dict _ _ _) = map (handleError Proxy) (L.get (Dict.dicts . Dict.errors) dict)
   where
     handleError :: Proxy a -> Error a -> DataDescription
     handleError d c = case c of


### PR DESCRIPTION
Awhile ago I noticed that there wasn't any documentation on how to set custom response headers in rest-core and made note of it in issue #59.  I was unaware at the time that there wasn't a facility for setting custom response headers.  Since I need this capability to support CORS, I've added a simple static header configuration that can be applied to any Handler, as shown below.  The tooling that I have submitted does not allow you to set headers based on the input environment or on the generated output, but I have been unable to come up with a situation when that would be warranted.  Though if there is interest in that functionality I am happy to look into what it would take to accomplish.

```haskell
get :: Handler WithInfo
get = defHead $ mkHandler (jsonO . someO) $ \e -> do
        i <- ask
        return $ SampleRes i

defHead :: Handler m -> Handler m
defHead = setResponseHeaders [("Access-Control-Allow-Origin", "www.your-domain.com")]
```