### PR TITLE
Move Range to rest-types

### DIFF
--- a/rest-core/src/Rest/Handler.hs
+++ b/rest-core/src/Rest/Handler.hs
@@ -1,4 +1,10 @@
-{-# LANGUAGE GADTs, KindSignatures, TupleSections, DeriveDataTypeable, TypeFamilies #-}
+{-# LANGUAGE
+    DeriveDataTypeable
+  , GADTs
+  , KindSignatures
+  , TupleSections
+  , TypeFamilies
+  #-}
 -- | Handlers for endpoints in a 'Resource'.
 module Rest.Handler
   ( -- * Single handlers.
@@ -27,11 +33,12 @@ module Rest.Handler
   , secureHandler
   ) where
 
-import Control.Arrow
 import Control.Applicative hiding (empty)
+import Control.Arrow
 import Control.Monad.Error
 import Control.Monad.Identity
 import Control.Monad.Reader
+import Rest.Types.Range
 import Safe
 
 import Rest.Dictionary
@@ -90,10 +97,6 @@ type ListHandler m = GenHandler m []
 
 secureHandler :: Handler m -> Handler m
 secureHandler h = h { secure = True }
-
--- | Data type for representing the requested range in list handlers.
-
-data Range = Range { offset :: Int, count :: Int }
 
 -- | Smart constructor for creating a list handler.
 -- Restricts the type of the 'Input' dictionary to 'None'

--- a/rest-types/rest-types.cabal
+++ b/rest-types/rest-types.cabal
@@ -25,6 +25,7 @@ library
     Rest.Types.Container.Resource
     Rest.Types.Info
     Rest.Types.Error
+    Rest.Types.Range
     Rest.Types.ShowUrl
   build-depends:
       base == 4.*

--- a/rest-types/src/Rest/Types/Range.hs
+++ b/rest-types/src/Rest/Types/Range.hs
@@ -1,0 +1,5 @@
+module Rest.Types.Range (Range (..)) where
+
+-- | Data type for representing the requested range in list handlers.
+
+data Range = Range { offset :: Int, count :: Int }


### PR DESCRIPTION
Is this a good change?

Also, this doesn't need a major bump of rest-core, right?

Motivation is the same for the other types moved to rest-types, you shouldn't need to depend on rest-core to use this type.
