### PR TITLE
Rest-gen modifyRequest

### DIFF
--- a/rest-gen/src/Rest/Gen/JavaScript.hs
+++ b/rest-gen/src/Rest/Gen/JavaScript.hs
@@ -51,10 +51,10 @@ mkRes ns node = mkStack $
 mkAccessorConstructor :: String -> ApiResource -> Code
 mkAccessorConstructor ns resource =
   let constrName = jsDir (cleanName (resName resource))
-  in functionDecl constrName ["url", "secureUrl", "cookieJar", "modifyRequest"] $
+  in functionDecl constrName ["url", "secureUrl", "modifyRequest"] $
        jsIf (code $ "this instanceof " ++ constrName)
-            (proc (ns ++ ".setContext") (code "this, url, secureUrl, cookieJar, modifyRequest"))
-         <-> jsElse (ret $ call (constrName ++ ".access") (code "url, secureUrl, cookieJar, modifyRequest"))
+            (proc (ns ++ ".setContext") (code "this, url, secureUrl, modifyRequest"))
+         <-> jsElse (ret $ call (constrName ++ ".access") (code "url, secureUrl, modifyRequest"))
 
 mkPreFuncs :: String -> ApiResource -> Code
 mkPreFuncs ns node =
@@ -84,7 +84,6 @@ mkAccessor ns node@(ApiAction _ _ ai) =
       [ var "postfix" $ "'" ++ urlPart ++ "'"
       , var "accessor" $ new "this" . code $  "this.contextUrl + postfix, "
                                            ++ "this.secureContextUrl + postfix, "
-                                           ++ "this.cookieJar, "
                                            ++ "this.modifyRequest"
       , "accessor.get" .=. mkFunction ns node
       , ret "accessor"
@@ -112,7 +111,6 @@ mkFunction ns (ApiAction _ _ ai) =
           , string $ mOut
           , maybe (code "undefined") (\(p, _, f) -> f (code p)) mInp
           , code "callOpts"
-          , code "this.cookieJar"
           , code "this.modifyRequest"
           ]
 


### PR DESCRIPTION
This adds a parameter when creating the api called modifyRequest. It is a function to alter the data of the request just before  performing it. It can be used to, for example, add new headers to the request.
