### PR TITLE
adjust the base js code, so it can be used with webpack

### DIFF
--- a/rest-gen/files/Javascript/base.js
+++ b/rest-gen/files/Javascript/base.js
@@ -20,9 +20,9 @@ var $apinamespace$ =
 
     this.cookieJar = isNodeJs ? obfuscatedRequire('request').jar() : undefined;
 
-    if(!modifyRequest) modifyRequest = function(req) { return req; };
+    if(!modifyRequest) modifyRequest = function (req) { return req; };
 
-    var finalModifyRequest = function(req)
+    var finalModifyRequest = function (req)
     {
       if (isNodeJs) req.jar = self.cookieJar;
       return modifyRequest(req);


### PR DESCRIPTION
Hi, thanks for the all quick feedback so far,
here is the PR.

I tested it with the **Rest-example** project, in the nodejs, webpack and normal browser environments with this code:

```
var Api = require("./api.js"); // api.js is the generated code
var api = new Api("http://localhost:3000/");
api.Post.list(function (s) {console.log(s)});
```
