### PR TITLE
Properly pluralize resource names

### DIFF
--- a/rest-gen/rest-gen.cabal
+++ b/rest-gen/rest-gen.cabal
@@ -61,6 +61,7 @@ library
     , hslogger >= 1.1 && < 1.3
     , hxt >= 9.2 && < 9.4
     , json-schema >= 0.6 && < 0.8
+    , Plural >= 0.0.2 && < 1.0
     , pretty >= 1.0 && < 1.2
     , process >= 1.0 && < 1.3
     , rest-core >= 0.31 && < 0.34

--- a/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
+++ b/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
@@ -63,6 +63,7 @@ import qualified Data.Foldable                as F
 import qualified Data.JSON.Schema             as J
 import qualified Data.Label.Total             as L
 import qualified Data.List.NonEmpty           as NList
+import Language.English.Plural (plural)
 import qualified Language.Haskell.Exts.Parser as H
 import qualified Language.Haskell.Exts.Syntax as H
 
@@ -527,8 +528,8 @@ mkActionDescription res ai =
       Retrieve   -> "Retrieve " ++ targetS ++ " data"
       Create     -> "Create " ++ targetS
       Delete     -> "Delete " ++ targetS
-      DeleteMany -> "Delete many " ++ targetS
-      List       -> "List " ++ targetS ++ "s"
+      DeleteMany -> "Delete many " ++ plural targetS
+      List       -> "List " ++ plural targetS
       Update     -> "Update " ++ targetS
-      UpdateMany -> "Update many " ++ targetS
+      UpdateMany -> "Update many " ++ plural targetS
       Modify     -> "Modify " ++ targetS

--- a/rest-gen/tests/Runner.hs
+++ b/rest-gen/tests/Runner.hs
@@ -29,15 +29,13 @@ main = do
               , testCase "Selects should show up only once." testSingleSelect
               , testCase "Removes should show up only once." testSingleRemove
               , testCase "Listing should have List type." testListingType
+              , testCase "Listing pluralization" testListingPluralization
               ]
 
 testListingParams :: Assertion
 testListingParams = assertEqual "Parameters" ["offset", "count"] (params actionInfo)
   where
-    [actionInfo] = resourceToActionInfo resource
-    resource :: Resource IO IO Void () Void
-    resource = mkResourceId { name = "resource", schema = Schema (Just (Many ())) (Named []), list = listHandler }
-    listHandler () = mkListing id $ \_ -> return []
+    [actionInfo] = resourceToActionInfo baseResource
 
 testSingleSelect :: Assertion
 testSingleSelect = assertEqual "Number of select ActionInfos." 1 (length actionInfos)
@@ -90,3 +88,22 @@ testListingType =
 
 instance IsString H.Type where
   fromString = H.fromParseResult . H.parse
+
+
+testListingPluralization :: Assertion
+testListingPluralization =
+  assertEqual "Listing should not doubly pluralize resource names"
+    "List things"
+    (mkActionDescription rn ai)
+  where
+    rn = "things"
+    ai = head $ listGetterActionInfo
+      baseResource { name = rn}
+      "/"
+      (Singleton ())
+
+
+baseResource :: Resource IO IO Void () Void
+baseResource = mkResourceId { name = "resource", schema = Schema (Just (Many ())) (Named []), list = listHandler }
+  where
+    listHandler () = mkListing id $ \_ -> return []


### PR DESCRIPTION
Ran into a minor issue. I use the plural naming of resources (posts, comments). The view was doubly pluralizing them (postss, commentss) and I didn't see an easy way to change this behavior in user space. This adds the Plural dependency, which brings in regex-tdfa, but it is not version bound and requires no external deps, so at worst this should just slow down compile time by a few seconds.
