### PR TITLE
More exhaustive documentation of JSON messages

### DIFF
--- a/rest-gen/src/Rest/Gen/Base/JSON.hs
+++ b/rest-gen/src/Rest/Gen/Base/JSON.hs
@@ -2,13 +2,16 @@
     CPP
   , OverloadedStrings
   #-}
-module Rest.Gen.Base.JSON (showExample) where
+module Rest.Gen.Base.JSON (showExample, showExamples) where
 
 import Data.Aeson ((.=))
 import Data.JSON.Schema
+import Data.List ( transpose )
+import Data.List.Split ( chunksOf )
 import Data.Maybe
 import Text.PrettyPrint.HughesPJ
 import qualified Data.Aeson  as A
+import qualified Data.Text   as T
 import qualified Data.Vector as V
 
 import Rest.Gen.Base.JSON.Pretty
@@ -31,6 +34,71 @@ showExample = render . pp_value . showExample'
 #if !MIN_VERSION_json_schema(0,7,0)
       Null         -> A.Null
 #endif
+
+
+-- | Generate enough examples as to mention every possible field
+--   at least once
+showExamples :: Schema -> [String]
+showExamples = map (render . pp_value) . showExamples'
+  where
+    -- Recursive types have infinite schemas, so we must ensure
+    -- that we don't generate infinitely deep examples in that case.
+    -- We thus impose a limit to the number of nestings
+    showExamples' = fst . go (10 :: Int)
+
+    -- Idea: @go n x == (showExamples' n x, length (showExamples' n x))@
+    -- and note that @snd (go x) >= 1@
+    go 0 _ = ([A.String "..."],1)
+    go n s = case s of
+      Choice []   -> ([A.Null], 1)
+
+      Choice xs   -> let (examples, numExamples) = unzip $ map (go $ n-1) xs
+                     in (concat examples, sum numExamples)
+
+      Object []   -> ([A.object []], 1)
+
+      Object fs   -> let (esByFld, numEsByFld) = unzip $ map (fieldExs n) fs
+                         numExamples = maximum numEsByFld
+                         examples = map A.object $ take numExamples $ transpose $ map cycle esByFld
+                     in (examples, numExamples)
+
+      Map v       -> let (examples, _) = go (n-1) v
+                         mkKey i = T.pack $ "<key " ++ show (i :: Int) ++ ">"
+                     in ([A.object [mkKey i .= e | (i,e) <- zip [1..] examples]], 1)
+
+      Tuple []    -> ([A.Array V.empty], 1)
+
+      Tuple vs    -> let (esByPos,numEsByPos) = unzip $ map (go $ n-1) vs
+                         numExamples = maximum numEsByPos
+                         examples = take numExamples $ transpose $ map cycle esByPos
+                     in (map (A.Array . V.fromList) examples, numExamples)
+
+      Array l _ v -> let minLen = fromMaybe 0 (lowerLength l)
+                         maxLen = fromMaybe (numCases `max` minLen) (upperLength l)
+                         (cases,numCases) = go (n-1) v
+                         (q,r) = numCases `divMod` maxLen
+                         numExamples = q + signum r
+                         examples = chunksOf maxLen $ cases ++ take (minLen - r) cases
+                     in if maxLen == 0 then ([A.Array V.empty], 1)
+                        else (map (A.Array . V.fromList) examples, numExamples)
+
+      Value _     -> ([A.String "value"], 1)
+
+      Boolean     -> ([A.Bool True], 1)
+
+      Number b    -> ([A.Number $ boundExample b], 1)
+
+      Any         -> ([A.String "<value>"],1)
+
+      Constant v  -> ([v], 1)
+
+#if !MIN_VERSION_json_schema(0,7,0)
+      Null        -> ([A.Null], 1)
+#endif
+
+    fieldExs n f = let (examples,num_examples) = go (n-1) (content f)
+                   in (map (key f .=) examples, num_examples)
+
 
 boundExample :: Num a => Bound -> a
 boundExample b = fromIntegral $ fromMaybe 0 (maybe (lower b) Just (upper b))

--- a/rest-gen/src/Rest/Gen/Docs.hs
+++ b/rest-gen/src/Rest/Gen/Docs.hs
@@ -33,7 +33,7 @@ import System.Directory
 import System.FilePath
 import System.Log.Logger
 import Text.Blaze.Html
-import Text.Blaze.Html5 hiding (map, meta)
+import Text.Blaze.Html5 hiding (map, meta, style)
 import Text.Blaze.Html5.Attributes hiding (method, span, title)
 import Text.Blaze.Html.Renderer.String
 import Text.StringTemplate
@@ -184,7 +184,9 @@ mkCode lng cap cd =
           do cdiv "modal-header" $
               do a ! href (toValue "#") ! cls "close" $ toHtml "x"
                  h3 $ toHtml cap
-             cdiv "modal-body" $ pre ! cls ("prettyprint lang-" ++ lng) $ toHtml $ cd
+             cdiv "modal-body" $
+               div ! style (toValue "overflow:auto; max-height:600px") $
+                 pre ! cls ("prettyprint lang-" ++ lng) $ toHtml $ cd
         button ! cls "btn open-modal"
                ! customAttribute (fromString "data-controls-modal") (toValue eid)
                ! customAttribute (fromString "data-backdrop") (toValue "true")


### PR DESCRIPTION
Implements the idea in #83, namely it provides examples covering all constructors that can appear, with a cut-off to circumvent infinite schemas.

Also adds a scroll-bar to the modal window, so that larger examples can be displayed.