### PR TITLE
Safer dicts

### DIFF
--- a/rest-core/src/Rest/Container.hs
+++ b/rest-core/src/Rest/Container.hs
@@ -24,6 +24,7 @@ import Rest.Dictionary
 import Rest.Error
 import Rest.StringMap.HashMap.Strict
 import Rest.Types.Container
+import Rest.Types.Void
 
 listI :: Inputs i -> Maybe (Inputs (Just (List (FromMaybe () i))))
 listI None       = Just (Dicts [XmlI, JsonI])
@@ -73,7 +74,7 @@ mappingO (Dicts os) =
     mappingDictO JsonO = Just JsonO
     mappingDictO _     = Nothing
 
-statusO :: (e ~ FromMaybe () e', o ~ FromMaybe () o')
+statusO :: (e ~ FromMaybe Void e', o ~ FromMaybe () o')
         => Errors e' -> Outputs o' -> Maybe (Outputs (Just (Status e o)))
 statusO None       None       = Just (Dicts [XmlO, JsonO])
 statusO None       (Dicts os) = mkStatusDict [XmlE, JsonE] os
@@ -100,7 +101,7 @@ intersect es os = [ (e, o) | e <- es, o <- os, e `eq` o ]
     JsonE `eq` JsonO = True
     _     `eq` _     = False
 
-reasonE :: e ~ FromMaybe () e' => Errors e' -> Errors (Just (Reason e))
+reasonE :: e ~ FromMaybe Void e' => Errors e' -> Errors (Just (Reason e))
 reasonE None       = Dicts [XmlE, JsonE]
 reasonE (Dicts es) = Dicts (map reasonDictE es)
   where

--- a/rest-core/src/Rest/Container.hs
+++ b/rest-core/src/Rest/Container.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE
-    DeriveDataTypeable
+    DataKinds
+  , DeriveDataTypeable
   , EmptyDataDecls
   , FlexibleInstances
   , GADTs
@@ -24,7 +25,7 @@ import Rest.Error
 import Rest.StringMap.HashMap.Strict
 import Rest.Types.Container
 
-listI :: Inputs a -> Maybe (Inputs (List a))
+listI :: Inputs i -> Maybe (Inputs (Just (List (FromMaybe () i))))
 listI None       = Just (Dicts [XmlI, JsonI])
 listI (Dicts is) =
   case mapMaybe listDictI is of
@@ -36,7 +37,7 @@ listI (Dicts is) =
     listDictI JsonI = Just JsonI
     listDictI _     = Nothing
 
-listO :: Outputs a -> Maybe (Outputs (List a))
+listO :: Outputs o -> Maybe (Outputs (Just (List (FromMaybe () o))))
 listO None       = Just (Dicts [XmlO, JsonO])
 listO (Dicts os) =
   case mapMaybe listDictO os of
@@ -48,7 +49,7 @@ listO (Dicts os) =
     listDictO JsonO = Just JsonO
     listDictO _     = Nothing
 
-mappingI :: forall i. Inputs i -> Maybe (Inputs (StringHashMap String i))
+mappingI :: forall i i'. i ~ FromMaybe () i' => Inputs i' -> Maybe (Inputs (Just (StringHashMap String i)))
 mappingI None       = Just (Dicts [XmlI, JsonI])
 mappingI (Dicts is) =
   case mapMaybe mappingDictI is of
@@ -60,7 +61,7 @@ mappingI (Dicts is) =
     mappingDictI JsonI = Just JsonI
     mappingDictI _     = Nothing
 
-mappingO :: forall o. Outputs o -> Maybe (Outputs (StringHashMap String o))
+mappingO :: forall o o'. o ~ FromMaybe () o' => Outputs o' -> Maybe (Outputs (Just (StringHashMap String o)))
 mappingO None       = Just (Dicts [XmlO, JsonO])
 mappingO (Dicts os) =
   case mapMaybe mappingDictO os of
@@ -72,13 +73,14 @@ mappingO (Dicts os) =
     mappingDictO JsonO = Just JsonO
     mappingDictO _     = Nothing
 
-statusO :: Errors e -> Outputs o -> Maybe (Outputs (Status e o))
+statusO :: (e ~ FromMaybe () e', o ~ FromMaybe () o')
+        => Errors e' -> Outputs o' -> Maybe (Outputs (Just (Status e o)))
 statusO None       None       = Just (Dicts [XmlO, JsonO])
 statusO None       (Dicts os) = mkStatusDict [XmlE, JsonE] os
 statusO (Dicts es) None       = mkStatusDict es           [XmlO, JsonO]
 statusO (Dicts es) (Dicts os) = mkStatusDict es           os
 
-mkStatusDict :: forall e o. [Error e] -> [Output o] -> Maybe (Outputs (Status e o))
+mkStatusDict :: forall e o. [Error e] -> [Output o] -> Maybe (Outputs (Just (Status e o)))
 mkStatusDict es os =
     case mapMaybe mappingDictO (intersect es os) of
       []  -> Nothing
@@ -98,7 +100,7 @@ intersect es os = [ (e, o) | e <- es, o <- os, e `eq` o ]
     JsonE `eq` JsonO = True
     _     `eq` _     = False
 
-reasonE :: Errors a -> Errors (Reason a)
+reasonE :: e ~ FromMaybe () e' => Errors e' -> Errors (Just (Reason e))
 reasonE None       = Dicts [XmlE, JsonE]
 reasonE (Dicts es) = Dicts (map reasonDictE es)
   where

--- a/rest-core/src/Rest/Dictionary/Combinators.hs
+++ b/rest-core/src/Rest/Dictionary/Combinators.hs
@@ -1,11 +1,16 @@
+{-# LANGUAGE
+    DataKinds
+  , TypeFamilies
+  , RankNTypes
+  , ScopedTypeVariables
+  #-}
 -- | Combinators for specifying the input/output dictionaries of a
 -- 'Handler'. The combinators can be combined using @(@'.'@)@.
 module Rest.Dictionary.Combinators
   (
   -- ** Input dictionaries
 
-    someI
-  , stringI
+    stringI
   , xmlTextI
   , fileI
   , readI
@@ -15,7 +20,6 @@ module Rest.Dictionary.Combinators
 
   -- ** Output dictionaries
 
-  , someO
   , stringO
   , fileO
   , xmlO
@@ -25,7 +29,6 @@ module Rest.Dictionary.Combinators
 
   -- ** Error dictionaries
 
-  , someE
   , jsonE
   , xmlE
 
@@ -45,6 +48,12 @@ module Rest.Dictionary.Combinators
 
   , mkPar
   , addPar
+
+  -- ** Deprecated
+
+  , someI
+  , someO
+  , someE
   ) where
 
 import Prelude hiding (id, (.))
@@ -85,118 +94,123 @@ addPar = L.modify params . TwoParams
 
 -- | Open up input type for extension with custom dictionaries.
 
-someI :: Dict h p () o e -> Dict h p i o e
-someI = L.set inputs (Dicts [])
+{-# DEPRECATED someI "This can be safely removed, it is now just the identity." #-}
+someI :: Dict h p i o e -> Dict h p i o e
+someI = id
 
 -- | Allow direct usage of as input as `String`.
 
-stringI :: Dict h p i o e -> Dict h p String o e
+stringI :: Dict h p Nothing o e -> Dict h p (Just String) o e
 stringI = L.set inputs (Dicts [StringI])
 
 -- | Allow direct usage of as input as raw Xml `Text`.
 
-xmlTextI :: Dict h p i o e -> Dict h p Text o e
+xmlTextI :: Dict h p Nothing o e -> Dict h p (Just Text) o e
 xmlTextI = L.set inputs (Dicts [XmlTextI])
 
 -- | Allow usage of input as file contents, represented as a `ByteString`.
 
-fileI :: Dict h p i o e -> Dict h p ByteString o e
+fileI :: Dict h p Nothing o e -> Dict h p (Just ByteString) o e
 fileI = L.set inputs (Dicts [FileI])
 
 -- | The input can be read into some instance of `Read`. For inspection reasons
 -- the type must also be an instance of both `Info` and `Show`.
 
-readI :: (Info i, Read i, Show i) => Dict h p i o e -> Dict h p i o e
-readI = L.modify (dicts . inputs) (ReadI:)
+readI :: (Info i, Read i, Show i, FromMaybe i i' ~ i) => Dict h p i' o e -> Dict h p (Just i) o e
+readI = L.modify inputs (modDicts (ReadI:))
 
 -- | The input can be read into some instance of `XmlPickler`.
 
-xmlI :: (Typeable i, XmlPickler i) => Dict h p i o e -> Dict h p i o e
-xmlI = L.modify (dicts . inputs) (XmlI:)
+xmlI :: (Typeable i, XmlPickler i, FromMaybe i i' ~ i) => Dict h p i' o e -> Dict h p (Just i) o e
+xmlI = L.modify inputs (modDicts (XmlI:))
 
 -- | The input can be used as an XML `ByteString`.
 
-rawXmlI :: Dict h p i o e -> Dict h p ByteString o e
+rawXmlI :: Dict h p Nothing o e -> Dict h p (Just ByteString) o e
 rawXmlI = L.set inputs (Dicts [RawXmlI])
 
 -- | The input can be read into some instance of `Json`.
 
-jsonI :: (Typeable i, FromJSON i, JSONSchema i) => Dict h p i o e -> Dict h p i o e
-jsonI = L.modify (dicts . inputs) (JsonI:)
+jsonI :: (Typeable i, FromJSON i, JSONSchema i, FromMaybe i i' ~ i) => Dict h p i' o e -> Dict h p (Just i) o e
+jsonI = L.modify inputs (modDicts (JsonI:))
 
 -- | Open up output type for extension with custom dictionaries.
 
-someO :: Dict h p i () e -> Dict h p i o e
-someO = L.set outputs (Dicts [])
+{-# DEPRECATED someO "This can be safely removed, it is now just the identity." #-}
+someO :: Dict h p i o e -> Dict h p i o e
+someO = id
 
 -- | Allow output as plain String.
 
-stringO :: Dict h p i () e -> Dict h p i String e
+stringO :: Dict h p i Nothing e -> Dict h p i (Just String) e
 stringO = L.set outputs (Dicts [StringO])
 
 -- | Allow file output using a combination of the raw data and a mime type.
 
-fileO :: Dict h p i o e -> Dict h p i (ByteString, String) e
+fileO :: Dict h p i Nothing e -> Dict h p i (Just (ByteString, String)) e
 fileO = L.set outputs (Dicts [FileO])
 
 -- | Allow output as XML using the `XmlPickler` type class.
 
-xmlO :: (Typeable o, XmlPickler o) => Dict h p i o e -> Dict h p i o e
-xmlO = L.modify (dicts . outputs) (XmlO:)
+xmlO :: (Typeable o, XmlPickler o, FromMaybe o o' ~ o) => Dict h p i o' e -> Dict h p i (Just o) e
+xmlO = L.modify outputs (modDicts (XmlO:))
 
 -- | Allow output as raw XML represented as a `ByteString`.
 
-rawXmlO :: Dict h p i () e -> Dict h p i ByteString e
+rawXmlO :: Dict h p i Nothing e -> Dict h p i (Just ByteString) e
 rawXmlO = L.set outputs (Dicts [RawXmlO])
 
 -- | Allow output as JSON using the `Json` type class.
 
-jsonO :: (Typeable o, ToJSON o, JSONSchema o) => Dict h p i o e -> Dict h p i o e
-jsonO = L.modify (dicts . outputs) (JsonO:)
+jsonO :: (Typeable o, ToJSON o, JSONSchema o, FromMaybe o o' ~ o) => Dict h p i o' e -> Dict h p i (Just o) e
+jsonO = L.modify outputs (modDicts (JsonO:))
 
 -- | Allow output as multipart. Writes out the ByteStrings separated
 -- by boundaries, with content type 'multipart/mixed'.
 
-multipartO :: Dict h p i () e -> Dict h p i [BodyPart] e
+multipartO :: Dict h p i Nothing e -> Dict h p i (Just [BodyPart]) e
 multipartO = L.set outputs (Dicts [MultipartO])
 
 -- | Open up error type for extension with custom dictionaries.
 
-someE :: (Typeable e, ToJSON e, JSONSchema e) => Dict h p i o () -> Dict h p i o e
-someE = L.set errors (Dicts [])
+{-# DEPRECATED someE "This can be safely removed, it is now just the identity." #-}
+someE :: Dict h p i o e -> Dict h p i o e
+someE = id
 
 -- | Allow error output as JSON using the `Json` type class.
 
-jsonE :: (ToResponseCode e, Typeable e, ToJSON e, JSONSchema e) => Dict h p i o e -> Dict h p i o e
-jsonE = L.modify (dicts . errors) (JsonE:)
+jsonE :: (ToResponseCode e, Typeable e, ToJSON e, JSONSchema e, FromMaybe e e' ~ e) => Dict h p i o e' -> Dict h p i o (Just e)
+jsonE = L.modify errors (modDicts (JsonE:))
 
 -- | Allow error output as XML using the `XmlPickler` type class.
 
-xmlE :: (ToResponseCode e, Typeable e, XmlPickler e) => Dict h p i o e -> Dict h p i o e
-xmlE = L.modify (dicts . errors) (XmlE:)
+xmlE :: (ToResponseCode e, Typeable e, XmlPickler e, FromMaybe e e' ~ e) => Dict h p i o e' -> Dict h p i o (Just e)
+xmlE = L.modify errors (modDicts (XmlE:))
 
 -- | The input can be read into some instance of both `Json` and `XmlPickler`.
 
-xmlJsonI :: (Typeable i, FromJSON i, JSONSchema i, XmlPickler i) => Dict h p () o e -> Dict h p i o e
-xmlJsonI = xmlI . jsonI . someI
+xmlJsonI :: (Typeable i, FromJSON i, JSONSchema i, XmlPickler i, FromMaybe i i' ~ i) => Dict h p i' o e -> Dict h p (Just i) o e
+xmlJsonI = xmlI . jsonI
 
 -- | Allow output as JSON using the `Json` type class and allow output as XML
 -- using the `XmlPickler` type class.
 
-xmlJsonO :: (Typeable o, ToJSON o, JSONSchema o, XmlPickler o) => Dict h p i () e -> Dict h p i o e
-xmlJsonO = xmlO . jsonO . someO
+xmlJsonO :: (Typeable o, ToJSON o, JSONSchema o, XmlPickler o, FromMaybe o o' ~ o) => Dict h p i o' e -> Dict h p i (Just o) e
+xmlJsonO = xmlO . jsonO
 
 -- | Allow error output as JSON using the `Json` type class and allow output as
 -- XML using the `XmlPickler` type class.
 
-xmlJsonE :: (ToResponseCode e, Typeable e, ToJSON e, JSONSchema e, XmlPickler e) => Dict h p i o () -> Dict h p i o e
-xmlJsonE = xmlE . jsonE . someE
+xmlJsonE :: (ToResponseCode e, Typeable e, ToJSON e, JSONSchema e, XmlPickler e, FromMaybe e e' ~ e) => Dict h p i o e' -> Dict h p i o (Just e)
+xmlJsonE = xmlE . jsonE
 
 -- | The input can be read into some instance of both `Json` and `XmlPickler`
 -- and allow output as JSON using the `Json` type class and allow output as XML
 -- using the `XmlPickler` type class.
 
-xmlJson :: (Typeable i, FromJSON i, JSONSchema i, XmlPickler i
-           ,Typeable o, ToJSON o, JSONSchema o, XmlPickler o)
-        => Dict h p () () e -> Dict h p i o e
+xmlJson :: ( Typeable i, FromJSON i, JSONSchema i, XmlPickler i
+           , Typeable o, ToJSON o, JSONSchema o, XmlPickler o
+           , FromMaybe i i' ~ i, FromMaybe o o' ~ o
+           )
+        => Dict h p i' o' e -> Dict h p (Just i) (Just o) e
 xmlJson = xmlJsonI . xmlJsonO

--- a/rest-core/src/Rest/Dictionary/Types.hs
+++ b/rest-core/src/Rest/Dictionary/Types.hs
@@ -67,6 +67,7 @@ import Text.XML.HXT.Arrow.Pickle
 
 import Rest.Error
 import Rest.Info
+import Rest.Types.Void
 
 -- | The `Format` datatype enumerates all input and output formats we might recognize.
 
@@ -245,7 +246,7 @@ empty = Dict NoHeader NoParam None None None
 -- | Custom existential packing an error together with a Reason.
 
 data SomeError where
-  SomeError :: Errors e -> Reason (FromMaybe () e) -> SomeError
+  SomeError :: Errors e -> Reason (FromMaybe Void e) -> SomeError
 
 -- | Type synonym for dictionary modification.
 

--- a/rest-core/src/Rest/Dictionary/Types.hs
+++ b/rest-core/src/Rest/Dictionary/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE
-    DataKinds
+    CPP
+  , DataKinds
   , FlexibleContexts
   , GADTs
   , KindSignatures
@@ -189,9 +190,15 @@ data Dicts f a where
 -- Needs UndecidableInstances
 deriving instance Show (f (FromMaybe Void a)) => Show (Dicts f a)
 
+#if GLASGOW_HASKELL < 708
+type family FromMaybe d (m :: Maybe *) :: *
+type instance FromMaybe b Nothing  = b
+type instance FromMaybe b (Just a) = a
+#else
 type family FromMaybe d (m :: Maybe *) :: * where
   FromMaybe b Nothing  = b
   FromMaybe b (Just a) = a
+#endif
 
 {-# DEPRECATED dicts "The modifier for this lens doesn't do anything when Dicts is None. Use getDicts and modDicts instead." #-}
 dicts :: forall a o f. o ~ FromMaybe o a => Dicts f a :-> [f o]

--- a/rest-core/src/Rest/Dictionary/Types.hs
+++ b/rest-core/src/Rest/Dictionary/Types.hs
@@ -1,9 +1,14 @@
 {-# LANGUAGE
-    FlexibleContexts
+    DataKinds
+  , FlexibleContexts
   , GADTs
+  , KindSignatures
+  , ScopedTypeVariables
   , StandaloneDeriving
   , TemplateHaskell
+  , TypeFamilies
   , TypeOperators
+  , UndecidableInstances
   #-}
 module Rest.Dictionary.Types
   (
@@ -36,10 +41,15 @@ module Rest.Dictionary.Types
 
   , Dicts (..)
   , dicts
+  , getDicts
+  , getDicts_
+  , modDicts
   , Inputs
   , Outputs
   , Errors
   , SomeError (..)
+
+  , FromMaybe
 
   )
 
@@ -172,19 +182,45 @@ type Outputs o = Dicts Output o
 type Errors  e = Dicts Error  e
 
 data Dicts f a where
-  None  :: Dicts f ()
-  Dicts :: [f a] -> Dicts f a
+  None  :: Dicts f Nothing
+  Dicts :: [f a] -> Dicts f (Just a)
 
-deriving instance Show (f a) => Show (Dicts f a)
+-- Needs UndecidableInstances
+deriving instance Show (f (FromMaybe Void a)) => Show (Dicts f a)
 
-dicts :: Dicts f a :-> [f a]
-dicts = lens getDicts modDicts
+type family FromMaybe d (m :: Maybe *) :: * where
+  FromMaybe b Nothing  = b
+  FromMaybe b (Just a) = a
+
+{-# DEPRECATED dicts "The modifier for this lens doesn't do anything when Dicts is None. Use getDicts and modDicts instead." #-}
+dicts :: forall a o f. o ~ FromMaybe o a => Dicts f a :-> [f o]
+dicts = lens get modify
   where
-    getDicts None       = []
-    getDicts (Dicts ds) = ds
-    modDicts :: ([f a] -> [f a]) -> Dicts f a -> Dicts f a
-    modDicts _ None       = None
-    modDicts f (Dicts ds) = Dicts (f ds)
+    get :: Dicts f a -> [f o]
+    get None       = []
+    get (Dicts ds) = ds
+    modify :: ([f o] -> [f o]) -> Dicts f a -> Dicts f a
+    modify _ None       = None
+    modify f (Dicts ds) = Dicts (f ds)
+
+-- | Get the list of dictionaries. If there are none, you get a [o].
+-- If this is too polymorphic, try `getDicts_`.
+
+getDicts :: o ~ FromMaybe o a => Dicts f a -> [f o]
+getDicts None       = []
+getDicts (Dicts ds) = ds
+
+-- | Get the list of dictionaries. If there are none, you get a [()].
+-- Sometimes useful to constraint the types if the element type of the
+-- list isn't clear from the context.
+
+getDicts_ :: o ~ FromMaybe () a => Dicts f a -> [f o]
+getDicts_ None = []
+getDicts_ (Dicts ds) = ds
+
+modDicts :: (FromMaybe o i ~ o) => ([f o] -> [f o]) -> Dicts f i -> Dicts f (Just o)
+modDicts f None       = Dicts (f [])
+modDicts f (Dicts ds) = Dicts (f ds)
 
 -- | The `Dict` datatype containing sub-dictionaries for translation of
 -- identifiers (i), headers (h), parameters (p), inputs (i), outputs (o), and
@@ -203,14 +239,14 @@ fclabels [d|
 
 -- | The empty dictionary, recognizing no types.
 
-empty :: Dict () () () () ()
+empty :: Dict () () Nothing Nothing Nothing
 empty = Dict NoHeader NoParam None None None
 
 -- | Custom existential packing an error together with a Reason.
 
 data SomeError where
-  SomeError :: Errors e -> Reason e -> SomeError
+  SomeError :: Errors e -> Reason (FromMaybe () e) -> SomeError
 
 -- | Type synonym for dictionary modification.
 
-type Modifier h p i o e = Dict () () () () () -> Dict h p i o e
+type Modifier h p i o e = Dict () () Nothing Nothing Nothing -> Dict h p i o e

--- a/rest-core/src/Rest/Driver/Perform.hs
+++ b/rest-core/src/Rest/Driver/Perform.hs
@@ -40,6 +40,7 @@ import Rest.Dictionary ( Dict, Dicts (..), Error (..), Errors, Format (..), Head
 import Rest.Driver.Types
 import Rest.Error
 import Rest.Handler
+import Rest.Types.Void
 import qualified Rest.Dictionary   as D
 import qualified Rest.Driver.Types as Rest
 
@@ -148,7 +149,7 @@ writeResponse (RunnableHandler run (GenHandler dict act _)) = do
 -------------------------------------------------------------------------------
 -- Fetching the input resource.
 
-fetchInputs :: Rest m => Dict h p j o e -> ErrorT (Reason (FromMaybe () e)) m (Env h p (FromMaybe () j))
+fetchInputs :: Rest m => Dict h p j o e -> ErrorT (Reason (FromMaybe Void e)) m (Env h p (FromMaybe () j))
 fetchInputs dict =
   do bs <- getBody
      ct <- parseContentType
@@ -220,7 +221,7 @@ parser f        (Dicts ds) v = parserD f ds
 -------------------------------------------------------------------------------
 -- Failure responses.
 
-failureWriter :: Rest m => Errors e -> Reason (FromMaybe () e) -> m UTF8.ByteString
+failureWriter :: Rest m => Errors e -> Reason (FromMaybe Void e) -> m UTF8.ByteString
 failureWriter es err =
   do formats <- accept
      fromMaybeT (printFallback formats) $
@@ -228,7 +229,7 @@ failureWriter es err =
             ++ (tryPrint (fallbackError formats) None <$> formats                 )
             )
   where
-    tryPrint :: forall m e e'. (e ~ FromMaybe () e', Rest m)
+    tryPrint :: forall m e e'. (e ~ FromMaybe Void e', Rest m)
              => Reason e -> Errors e' -> Format -> MaybeT m UTF8.ByteString
     tryPrint e None JsonFormat = printError JsonFormat (toResponseCode e) (encode e)
     tryPrint e None XmlFormat  = printError XmlFormat  (toResponseCode e) (UTF8.fromString (toXML e))

--- a/rest-core/src/Rest/Driver/Routing.hs
+++ b/rest-core/src/Rest/Driver/Routing.hs
@@ -319,7 +319,7 @@ mkMultiHandler sBy run (GenHandler dict act sec) = GenHandler <$> mNewDict <*> p
          return . StringHashMap.fromList $ zipWith (\(k, _) b -> (k, eitherToStatus b)) (StringHashMap.toList vs) bs
 
 mkMultiGetHandler :: forall m s. (Applicative m, Monad m) => Rest.Router m s -> Handler m
-mkMultiGetHandler root = mkInputHandler (xmlJsonI . someI . multipartO) $ \(Resources rs) -> multiGetHandler rs
+mkMultiGetHandler root = mkInputHandler (xmlJsonI . multipartO) $ \(Resources rs) -> multiGetHandler rs
   where
     multiGetHandler rs = lift $
       do mapM (runResource root) rs

--- a/rest-core/src/Rest/Handler.hs
+++ b/rest-core/src/Rest/Handler.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE
-    DeriveDataTypeable
+    DataKinds
+  , DeriveDataTypeable
   , GADTs
   , KindSignatures
   , TupleSections
@@ -68,8 +69,8 @@ data Env h p i = Env
 -- running the API.
 
 data GenHandler m f where
-  GenHandler ::
-    { dictionary :: Dict h p i o e
+  GenHandler :: (i ~ FromMaybe () i', o ~ FromMaybe () o', e ~ FromMaybe () e') =>
+    { dictionary :: Dict h p i' o' e'
     , handler    :: Env h p i -> ErrorT (Reason e) m (Apply f o)
     , secure     :: Bool
     } -> GenHandler m f
@@ -77,7 +78,10 @@ data GenHandler m f where
 -- | Construct a 'GenHandler' using a 'Modifier' instead of a 'Dict'.
 -- The 'secure' flag will be 'False'.
 
-mkGenHandler :: Monad m => Modifier h p i o e -> (Env h p i -> ErrorT (Reason e) m (Apply f o)) -> GenHandler m f
+mkGenHandler :: (Monad m, i ~ FromMaybe () i', o ~ FromMaybe () o', e ~ FromMaybe () e')
+             => Modifier h p i' o' e'
+             -> (Env h p i -> ErrorT (Reason e) m (Apply f o))
+             -> GenHandler m f
 mkGenHandler d a = GenHandler (d empty) a False
 
 -- | Apply a Functor @f@ to a type @a@. In general will result in @f
@@ -102,8 +106,8 @@ secureHandler h = h { secure = True }
 -- Restricts the type of the 'Input' dictionary to 'None'
 
 mkListing
-  :: Monad m
-  => Modifier h p () o e
+  :: (Monad m, o ~ FromMaybe () o', e ~ FromMaybe () e')
+  => Modifier h p Nothing o' e'
   -> (Range -> ErrorT (Reason e) m [o])
   -> ListHandler m
 mkListing d a = mkGenHandler (mkPar range . d) (a . param)
@@ -129,8 +133,8 @@ range = Param ["offset", "count"] $ \xs ->
 -- Restricts the type of the 'Input' dictionary to 'None'
 
 mkOrderedListing
-  :: Monad m
-  => Modifier h p () o e
+  :: (Monad m, o ~ FromMaybe () o', e ~ FromMaybe () e')
+  => Modifier h p Nothing o' e'
   -> ((Range, Maybe String, Maybe String) -> ErrorT (Reason e) m [o])
   -> ListHandler m
 mkOrderedListing d a = mkGenHandler (mkPar orderedRange . d) (a . param)
@@ -155,23 +159,27 @@ orderedRange = Param ["offset", "count", "order", "direction"] $ \xs ->
 -- | Create a handler for a single resource. Takes the entire
 -- environmend as input.
 
-mkHandler :: Monad m => Modifier h p i o e -> (Env h p i -> ErrorT (Reason e) m o) -> Handler m
+mkHandler :: (Monad m, i ~ FromMaybe () i', o ~ FromMaybe () o', e ~ FromMaybe () e')
+          => Modifier h p i' o' e' -> (Env h p i -> ErrorT (Reason e) m o) -> Handler m
 mkHandler = mkGenHandler
 
 -- | Create a handler for a single resource. Takes only the body
 -- information as input.
 
-mkInputHandler :: Monad m => Modifier () () i o e -> (i -> ErrorT (Reason e) m o) -> Handler m
+mkInputHandler :: (Monad m, i ~ FromMaybe () i', o ~ FromMaybe () o', e ~ FromMaybe () e')
+               => Modifier () () i' o' e' -> (i -> ErrorT (Reason e) m o) -> Handler m
 mkInputHandler d a = mkHandler d (a . input)
 
 -- | Create a handler for a single resource. Doesn't take any input.
 
-mkConstHandler :: Monad m => Modifier () () () o e -> ErrorT (Reason e) m o -> Handler m
+mkConstHandler :: (Monad m, o ~ FromMaybe () o', e ~ FromMaybe () e')
+               => Modifier () () Nothing o' e' -> ErrorT (Reason e) m o -> Handler m
 mkConstHandler d a = mkHandler d (const a)
 
 -- | Create a handler for a single resource. Take body information and
 -- the resource identifier as input. The monad @m@ should be a
 -- 'Reader'-like type containing the idenfier.
 
-mkIdHandler :: MonadReader id m => Modifier h p i o e -> (i -> id -> ErrorT (Reason e) m o) -> Handler m
+mkIdHandler :: (MonadReader id m, i ~ FromMaybe () i', o ~ FromMaybe () o', e ~ FromMaybe () e')
+            => Modifier h p i' o' e' -> (i -> id -> ErrorT (Reason e) m o) -> Handler m
 mkIdHandler d a = mkHandler d (\env -> ask >>= a (input env))

--- a/rest-core/src/Rest/Resource.hs
+++ b/rest-core/src/Rest/Resource.hs
@@ -12,13 +12,21 @@
 -- | A 'Resource' type for representing a REST resource, as well as
 -- smart constructors for empty resources which can them be filled in
 -- using record updates.
-module Rest.Resource where
+module Rest.Resource
+  ( Resource (..)
+  , mkResource
+  , mkResourceId
+  , mkResourceReader
+  , mkResourceReaderWith
+  , module Rest.Types.Void
+  ) where
 
 import Control.Applicative (Applicative)
 import Control.Monad.Reader
 
 import Rest.Handler
 import Rest.Schema (Schema (..), Step (..))
+import Rest.Types.Void
 
 -- * The @Resource@ type.
 
@@ -91,11 +99,3 @@ mkResourceReader = mkResourceReaderWith id
 
 mkResourceReaderWith :: (Applicative m, Monad m, Applicative s, Monad s) => (forall b. s b -> ReaderT sid m b) -> Resource m s sid Void Void
 mkResourceReaderWith f = mkResource (\a -> flip runReaderT a . f)
-
--- * The @Void@ type.
-
--- | The 'Void' type is used as the identifier for resources that
--- can't be routed to. It contains no values apart from bottom.
-
-newtype Void = Void { magic :: forall a. a }
-

--- a/rest-example/example-api/Api/Post/Comment.hs
+++ b/rest-example/example-api/Api/Post/Comment.hs
@@ -52,7 +52,7 @@ create = mkInputHandler xmlJson $ \ucomm -> do
     modifyTVar' comms (H.insertWith (<>) postId (Set.singleton comm))
   return comm
 
-getPostId :: ErrorT (Reason ()) WithPost (Maybe Post.Id)
+getPostId :: ErrorT Reason_ WithPost (Maybe Post.Id)
 getPostId = do
   postIdent <- ask
   return . fmap Post.id

--- a/rest-example/example-api/Api/Test.hs
+++ b/rest-example/example-api/Api/Test.hs
@@ -71,41 +71,41 @@ noResponse :: Handler WithText
 noResponse = mkConstHandler id $ return ()
 
 onlyError :: Handler WithText
-onlyError = mkConstHandler (jsonE . someE) $
+onlyError = mkConstHandler jsonE $
   throwError $ domainReason Err
 
 differentFormats :: Handler WithText
-differentFormats = mkInputHandler (jsonE . someE . xmlO . someO . stringI . someI) $
+differentFormats = mkInputHandler (jsonE . xmlO . stringI) $
   \case
     "error" -> throwError $ domainReason Err
     _       -> return Ok
 
 intersectedFormats :: Handler WithText
-intersectedFormats = mkInputHandler (jsonE . someE . xmlO . jsonO . someO . stringI . someI) $
+intersectedFormats = mkInputHandler (jsonE . xmlO . jsonO . stringI) $
   \case
     "error" -> throwError $ domainReason Err
     _       -> return Ok
 
 intersectedFormats2 :: Handler WithText
-intersectedFormats2 = mkInputHandler (xmlE . someE . xmlO . jsonO . someO . stringI . someI) $
+intersectedFormats2 = mkInputHandler (xmlE . xmlO . jsonO . stringI) $
   \case
     "error" -> throwError $ domainReason Err
     _       -> return Ok
 
 errorImport :: Handler WithText
-errorImport = mkIdHandler (stringI . rawXmlO . xmlE . someE) $ \s (_::Text) ->
+errorImport = mkIdHandler (stringI . rawXmlO . xmlE) $ \s (_::Text) ->
   case s of
     "error" -> throwError $ domainReason E2.Err
     _       -> return "<ok/>"
 
 noError :: Handler WithText
-noError = mkConstHandler (jsonO . someO) $ return Ok
+noError = mkConstHandler jsonO $ return Ok
 
 justStringO :: Handler WithText
-justStringO = mkConstHandler (stringO . someO) $ return "Ok"
+justStringO = mkConstHandler stringO $ return "Ok"
 
 preferJson :: Handler WithText
-preferJson = mkInputHandler (xmlJsonO . xmlJsonE . stringI . someI) $
+preferJson = mkInputHandler (xmlJsonO . xmlJsonE . stringI) $
   \case
     "error" -> throwError $ domainReason Err
     _       -> return Ok

--- a/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
+++ b/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE
-    GADTs
+    DataKinds
+  , GADTs
+  , KindSignatures
   , LambdaCase
   , NoMonomorphismRestriction
   , ScopedTypeVariables
@@ -424,9 +426,9 @@ paramNames_ (TwoParams p1 p2) = paramNames p1 ++ paramNames p2
 
 -- | Extract input description from handlers
 handlerInputs :: Handler m -> [DataDescription]
-handlerInputs (GenHandler dict _ _) = map (handlerInput Proxy) (L.get (Dict.dicts . Dict.inputs) dict)
+handlerInputs (GenHandler dict _ _) = map (handlerInput Proxy) (Dict.getDicts_ . L.get Dict.inputs $ dict)
   where
-    handlerInput :: Proxy a -> Input a -> DataDescription
+    handlerInput :: Proxy i -> Input i -> DataDescription
     handlerInput d c = case c of
       ReadI    -> L.set (haskellModules . desc) (modString d)
                 $ defaultDescription Other (describe d) (toHaskellType d)
@@ -444,7 +446,7 @@ handlerInputs (GenHandler dict _ _) = map (handlerInput Proxy) (L.get (Dict.dict
 
 -- | Extract output description from handlers
 handlerOutputs :: Handler m -> [DataDescription]
-handlerOutputs (GenHandler dict _ _) = map (handlerOutput Proxy) (L.get (Dict.dicts . Dict.outputs) dict)
+handlerOutputs (GenHandler dict _ _) = map (handlerOutput Proxy) (Dict.getDicts_ . L.get Dict.outputs $ dict)
   where
     handlerOutput :: Proxy a -> Output a -> DataDescription
     handlerOutput d c = case c of
@@ -461,7 +463,7 @@ handlerOutputs (GenHandler dict _ _) = map (handlerOutput Proxy) (L.get (Dict.di
 
 -- | Extract input description from handlers
 handlerErrors :: Handler m -> [DataDescription]
-handlerErrors (GenHandler dict _ _) = map (handleError Proxy) (L.get (Dict.dicts . Dict.errors) dict)
+handlerErrors (GenHandler dict _ _) = map (handleError Proxy) (Dict.getDicts_ . L.get Dict.errors $ dict)
   where
     handleError :: Proxy a -> Error a -> DataDescription
     handleError d c = case c of

--- a/rest-gen/src/Rest/Gen/Haskell.hs
+++ b/rest-gen/src/Rest/Gen/Haskell.hs
@@ -412,6 +412,6 @@ defaultErrorDataDesc :: DataType -> DataDesc
 defaultErrorDataDesc dt =
   DataDesc
     { _dataType       = dt
-    , _haskellType    = haskellUnitType
-    , _haskellModules = []
+    , _haskellType    = haskellVoidType
+    , _haskellModules = [ModuleName "Rest.Types.Void"]
     }

--- a/rest-gen/src/Rest/Gen/Types.hs
+++ b/rest-gen/src/Rest/Gen/Types.hs
@@ -8,6 +8,7 @@ module Rest.Gen.Types
   , haskellByteStringType
   , haskellUnitType
   , haskellSimpleType
+  , haskellVoidType
   , noLoc
   , ModuleName (..)
   , ImportDecl (..)
@@ -53,3 +54,6 @@ haskellSimpleType = TyCon . UnQual . Ident
 
 haskellUnitType :: Type
 haskellUnitType = TyCon (Special UnitCon)
+
+haskellVoidType :: Type
+haskellVoidType = TyCon (Qual (ModuleName "Rest.Types.Void") (Ident "Void"))

--- a/rest-types/rest-types.cabal
+++ b/rest-types/rest-types.cabal
@@ -27,6 +27,7 @@ library
     Rest.Types.Info
     Rest.Types.Range
     Rest.Types.ShowUrl
+    Rest.Types.Void
   build-depends:
       base == 4.*
     , aeson >= 0.7 && < 0.9

--- a/rest-types/src/Rest/Types/Error.hs
+++ b/rest-types/src/Rest/Types/Error.hs
@@ -38,6 +38,8 @@ import Text.XML.HXT.Arrow.Pickle.Schema
 import Text.XML.HXT.Arrow.Pickle.Xml
 import qualified Data.JSON.Schema as JSONSchema
 
+import Rest.Types.Void
+
 -- Error utilities.
 
 data DataError
@@ -83,7 +85,7 @@ toEither :: Status a b -> Either a b
 toEither (Success x) = Right x
 toEither (Failure y) = Left  y
 
-type Reason_ = Reason ()
+type Reason_ = Reason Void
 
 data Reason a
   -- Thrown in the router.
@@ -153,10 +155,8 @@ instance JSONSchema SomeReason where
 class ToResponseCode a where
   toResponseCode :: a -> Int
 
--- This instance shouldn't be here, and instead the None dictionary in
--- Rest.Dictionary.Types should have type Dicts f Void.
-instance ToResponseCode () where
-  toResponseCode () = 500
+instance ToResponseCode Void where
+  toResponseCode = magic
 
 instance ToResponseCode a => ToResponseCode (Reason a) where
   toResponseCode e =

--- a/rest-types/src/Rest/Types/Void.hs
+++ b/rest-types/src/Rest/Types/Void.hs
@@ -4,7 +4,7 @@
   #-}
 module Rest.Types.Void (Void (..)) where
 
-import Data.Aeson (ToJSON (..))
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.JSON.Schema (JSONSchema (..), Schema(Choice))
 import Data.Typeable (Typeable)
 import Text.XML.HXT.Arrow.Pickle (XmlPickler (..), PU (..))
@@ -18,15 +18,19 @@ import Text.XML.HXT.Arrow.Pickle.Xml (Unpickler (UP))
 
 newtype Void = Void { magic :: forall a. a } deriving (Typeable)
 
+-- This instance is needed for generated API clients.
+
+instance FromJSON Void where
+  parseJSON = fail "Cannot parse Void in FromJSON."
+
 instance ToJSON Void where
   toJSON = magic
 
 instance JSONSchema Void where
   schema _ = Choice []
 
--- | We'd rather not have the unpickler (like we don't have
--- `FromJSON`) but they are packed together. Unpickling gives an
--- error.
-
 instance XmlPickler Void where
   xpickle = PU magic (UP (\st -> (Left ("Cannot unpickle Void.", st), st))) (Alt [])
+
+instance Show Void where
+  show = magic

--- a/rest-types/src/Rest/Types/Void.hs
+++ b/rest-types/src/Rest/Types/Void.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE
+    DeriveDataTypeable
+  , RankNTypes
+  #-}
+module Rest.Types.Void (Void (..)) where
+
+import Data.Aeson (ToJSON (..))
+import Data.JSON.Schema (JSONSchema (..), Schema(Choice))
+import Data.Typeable (Typeable)
+import Text.XML.HXT.Arrow.Pickle (XmlPickler (..), PU (..))
+import Text.XML.HXT.Arrow.Pickle.Schema (Schema(Alt))
+import Text.XML.HXT.Arrow.Pickle.Xml (Unpickler (UP))
+
+-- * The @Void@ type.
+
+-- | The 'Void' type is used as the identifier for resources that
+-- can't be routed to. It contains no values apart from bottom.
+
+newtype Void = Void { magic :: forall a. a } deriving (Typeable)
+
+instance ToJSON Void where
+  toJSON = magic
+
+instance JSONSchema Void where
+  schema _ = Choice []
+
+-- | We'd rather not have the unpickler (like we don't have
+-- `FromJSON`) but they are packed together. Unpickling gives an
+-- error.
+
+instance XmlPickler Void where
+  xpickle = PU magic (UP (\st -> (Left ("Cannot unpickle Void.", st), st))) (Alt [])

--- a/rest-types/src/Rest/Types/Void.hs
+++ b/rest-types/src/Rest/Types/Void.hs
@@ -1,12 +1,15 @@
 {-# LANGUAGE
     DeriveDataTypeable
+  , EmptyDataDecls
   , RankNTypes
+  , TypeFamilies
   #-}
 module Rest.Types.Void (Void (..)) where
 
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.JSON.Schema (JSONSchema (..), Schema(Choice))
 import Data.Typeable (Typeable)
+import GHC.Generics
 import Text.XML.HXT.Arrow.Pickle (XmlPickler (..), PU (..))
 import Text.XML.HXT.Arrow.Pickle.Schema (Schema(Alt))
 import Text.XML.HXT.Arrow.Pickle.Xml (Unpickler (UP))
@@ -34,3 +37,16 @@ instance XmlPickler Void where
 
 instance Show Void where
   show = magic
+
+-- | Generic. Can't derive it, sadly.
+
+instance Generic Void where
+  type Rep Void = D1 D1Void V1
+  from = magic
+  to (M1 x) = x `seq` Void (error "Impossible: constructing a Void in Generic instance.")
+
+data D1Void
+
+instance Datatype D1Void where
+  datatypeName _ = "Void"
+  moduleName _ = "Rest.Types.Void"


### PR DESCRIPTION
This uses the trick @sebastiaanvisser and I found while working on the extensible dictionaries: encoding the return type of the dictionaries with a type level `Maybe`, using `Nothing` to indicate no dictionaries. Then we can use `FromMaybe` to sometimes choose polymorphism and sometimes choose `()` for the empty list.

On top of that, I could also implement `Reason_` as `Reason Void` instead of `Reason ()`, which failed before because the `Dicts` had a `()` as a return type for the empty case.

This does make things quite a bit more complicated internally, but externally it makes things a bit simpler: all the `some*` combinators are gone. It's also more correct. What do the rest of you think about it?

I might make the list in `Dicts` a non-empty list as well, and see if that solves more problems.