### PR TITLE
Add PathHeader to access require path in Handlers

### DIFF
--- a/rest-core/src/Rest/Dictionary/Types.hs
+++ b/rest-core/src/Rest/Dictionary/Types.hs
@@ -83,11 +83,13 @@ deriving instance Show (Ident id)
 -- headers to some Haskell value. The first field in the `Header` constructor
 -- is a white list of headers we can recognize, used in generic validation and
 -- for generating documentation. The second field is a custom parser that can
--- fail with a `DataError` or can produce a some value. When explicitly not
--- interested in the headers we can use `NoHeader`.
+-- fail with a `DataError` or can produce a some value. When we want only the
+-- path from the HTTP request we can use the `PathHeader` constructor. When
+-- explicitly not interested in the headers we can use `NoHeader`.
 
 data Header h where
   NoHeader    ::                                                       Header ()
+  PathHeader  ::                                                       Header String
   Header      :: [String] -> ([Maybe String] -> Either DataError h) -> Header h
   TwoHeaders  :: Header h -> Header k                               -> Header (h,k)
 

--- a/rest-core/src/Rest/Driver/Perform.hs
+++ b/rest-core/src/Rest/Driver/Perform.hs
@@ -187,6 +187,7 @@ parseContentType =
 
 headers :: Rest m => Header h -> ErrorT DataError m h
 headers NoHeader      = return ()
+headers PathHeader    = intercalate "/" <$> getPaths
 headers (Header xs h) = mapM getHeader xs >>= either throwError return . h
 headers (TwoHeaders h1 h2) = (,) <$> headers h1 <*> headers h2
 


### PR DESCRIPTION
Add a PathHeader constructor to the Header data type, allowing Handlers to require the HTTP request path be provided in their environment.

My use case is this: my team are working on a generics-based tool to publish a bunch of record types as an API and I'm building, as part of that, a facility to "watch" resources and get POST callbacks when they are modified. I'm using the URI to identify resources which, but this means that the Handlers need to be able to get the URI for the current resource.

As far as I can tell, there currently is no way to do this so I've added support for a magical and special "request path" header.

If someone will let me know I'm not barking up the wrong tree here, I'll flesh this out with some tests, etc.