### PR TITLE
Top level multi POST

### DIFF
--- a/rest-core/src/Rest/Driver/Perform.hs
+++ b/rest-core/src/Rest/Driver/Perform.hs
@@ -45,7 +45,7 @@ class (Applicative m, Monad m) => Rest m where
   getHeader       :: String -> m (Maybe String)
   getParameter    :: String -> m (Maybe String)
   getBody         :: m UTF8.ByteString
-  getMethod       :: m Rest.Method
+  getMethod       :: m (Maybe Rest.Method)
   getPaths        :: m [String]
   lookupMimeType  :: String -> m (Maybe String)
   setHeader       :: String -> String -> m ()

--- a/rest-core/src/Rest/Driver/RestM.hs
+++ b/rest-core/src/Rest/Driver/RestM.hs
@@ -23,7 +23,7 @@ data RestInput = RestInput
   { headers    :: HashMap String String
   , parameters :: HashMap String String
   , body       :: UTF8.ByteString
-  , method     :: Rest.Method
+  , method     :: Maybe Rest.Method
   , paths      :: [String]
   , mimeTypes  :: HashMap String String
   }
@@ -33,7 +33,7 @@ emptyInput = RestInput
   { headers    = H.empty
   , parameters = H.empty
   , body       = mempty
-  , method     = Rest.GET
+  , method     = Just Rest.GET
   , paths      = []
   , mimeTypes  = H.empty
   }

--- a/rest-core/src/Rest/Driver/Routing.hs
+++ b/rest-core/src/Rest/Driver/Routing.hs
@@ -97,7 +97,7 @@ routeRoot router@(Rest.Embed resource _) = do
 routeMultiGet :: Rest.Router m s -> MaybeT Router (RunnableHandler m)
 routeMultiGet root@(Rest.Embed Rest.Resource{} _) =
   do guardNullPath
-     guardMethods [GET, POST]
+     guardMethod POST
      return (RunnableHandler id (mkMultiGetHandler root))
 
 routeRouter :: Rest.Router m s -> Router (RunnableHandler m)
@@ -292,9 +292,6 @@ hasMethod wantedMethod = ask >>= \method ->
 
 guardMethod :: (MonadPlus m, MonadReader Method m) => Method -> m ()
 guardMethod method = ask >>= guard . (== method)
-
-guardMethods :: (MonadPlus m, MonadReader Method m) => [Method] -> m ()
-guardMethods methods = ask >>= guard . (`elem` methods)
 
 mkListHandler :: Monad m => ListHandler m -> Maybe (Handler m)
 mkListHandler (GenHandler dict act sec) =

--- a/rest-core/src/Rest/Driver/Routing.hs
+++ b/rest-core/src/Rest/Driver/Routing.hs
@@ -81,8 +81,9 @@ runRouter method uri = runIdentity
                      . flip runReaderT method
                      . unRouter
 
-route :: Method -> UriParts -> Rest.Api m -> Either Reason_ (RunnableHandler m)
-route method uri api = runRouter method uri $
+route :: Maybe Method -> UriParts -> Rest.Api m -> Either Reason_ (RunnableHandler m)
+route Nothing       _   _   = apiError UnsupportedMethod
+route (Just method) uri api = runRouter method uri $
   do versionStr <- popSegment
      case versionStr `Rest.lookupVersion` api of
           Just (Some1 router) -> routeRoot router

--- a/rest-core/src/Rest/Driver/Routing.hs
+++ b/rest-core/src/Rest/Driver/Routing.hs
@@ -344,6 +344,7 @@ runResource root res
       { Rest.headers    = H.map (R.unValue) . StringHashMap.toHashMap . R.headers    $ r
       , Rest.parameters = H.map (R.unValue) . StringHashMap.toHashMap . R.parameters $ r
       , Rest.body       = LUTF8.fromString (R.input r)
+      , Rest.method     = Just (R.method r)
       , Rest.paths      = splitUriString (R.uri r)
       }
 

--- a/rest-core/src/Rest/Driver/Types.hs
+++ b/rest-core/src/Rest/Driver/Types.hs
@@ -1,7 +1,14 @@
 {-# LANGUAGE ExistentialQuantification, RankNTypes #-}
-module Rest.Driver.Types where
+module Rest.Driver.Types
+  ( Run
+  , RunnableHandler (..)
+  , mapHandler
+
+  , module Rest.Types.Method
+  ) where
 
 import Rest.Handler (Handler)
+import Rest.Types.Method (Method (..))
 
 type Run m n = forall a. m a -> n a
 
@@ -11,6 +18,3 @@ data RunnableHandler n = forall m. RunnableHandler
 
 mapHandler :: Run m n -> RunnableHandler m -> RunnableHandler n
 mapHandler run (RunnableHandler run' h) = RunnableHandler (run . run') h
-
-data Method = GET | PUT | POST | DELETE | Unknown String
-  deriving (Show, Eq)

--- a/rest-core/tests/Runner.hs
+++ b/rest-core/tests/Runner.hs
@@ -42,7 +42,6 @@ main = do
               , testCase "Simple subresource." testSubresource
               , testCase "Root router is skipped." testRootRouter
               , testCase "Multi-PUT." testMultiPut
-              , testCase "Multi-GET." testMultiGet
               , testCase "Multi-POST" testMultiPost
               , testCase "Accept headers." testAcceptHeaders
               ]
@@ -163,11 +162,8 @@ testMultiPut = checkRouteSuccess PUT "resource/foo" (Rest.root -/ Rest.route res
       , update = Just (mkConstHandler xmlJsonO (liftM void ask))
       }
 
-testMultiGet :: Assertion
-testMultiGet = checkRouteSuccess GET "" (Rest.root :: Rest.Router IO IO)
-
 testMultiPost :: Assertion
-testMultiPost = checkRouteSuccess POST "" (Rest.root :: Rest.Router IO IO)
+testMultiPost = checkRoute POST "" (Rest.root :: Rest.Router IO IO)
 
 type Uri = String
 

--- a/rest-core/tests/Runner.hs
+++ b/rest-core/tests/Runner.hs
@@ -195,13 +195,13 @@ checkRouteWithIgnoredMethods ignoredMethods router method uri =
 
 checkRouteFailure :: Method -> Uri -> Rest.Router m s -> Assertion
 checkRouteFailure method uri router =
-  case route method (splitUriString $ "v1.0/" <> uri) [(Version 1 0 Nothing, Some1 router)] of
+  case route (Just method) (splitUriString $ "v1.0/" <> uri) [(Version 1 0 Nothing, Some1 router)] of
     Left _  -> return ()
     Right _ -> assertFailure ("Should be no route to " ++ show method ++ " " ++ uri ++ ".")
 
 checkRouteSuccess :: Method -> Uri -> Rest.Router m s -> Assertion
 checkRouteSuccess method uri router =
-  case route method (splitUriString $ "v1.0/" <> uri) [(Version 1 0 Nothing, Some1 router)] of
+  case route (Just method) (splitUriString $ "v1.0/" <> uri) [(Version 1 0 Nothing, Some1 router)] of
     Left e  -> assertFailure ("No route to " ++ show method ++ " " ++ uri ++ ": " ++ show e)
     Right _ -> return ()
 

--- a/rest-happstack/src/Rest/Driver/Happstack.hs
+++ b/rest-happstack/src/Rest/Driver/Happstack.hs
@@ -38,9 +38,9 @@ instance (Functor m, MonadPlus m, MonadIO m) => Rest (ServerPartT m) where
   setHeader       = Happstack.setHeaderM
   setResponseCode = Happstack.setResponseCode
 
-toRestMethod :: Happstack.Method -> Rest.Method
-toRestMethod Happstack.GET    = Rest.GET
-toRestMethod Happstack.POST   = Rest.POST
-toRestMethod Happstack.PUT    = Rest.PUT
-toRestMethod Happstack.DELETE = Rest.DELETE
-toRestMethod mthd             = Rest.Unknown (show mthd)
+toRestMethod :: Happstack.Method -> Maybe Rest.Method
+toRestMethod Happstack.GET    = Just Rest.GET
+toRestMethod Happstack.POST   = Just Rest.POST
+toRestMethod Happstack.PUT    = Just Rest.PUT
+toRestMethod Happstack.DELETE = Just Rest.DELETE
+toRestMethod _                = Nothing

--- a/rest-snap/src/Rest/Driver/Snap.hs
+++ b/rest-snap/src/Rest/Driver/Snap.hs
@@ -36,9 +36,9 @@ instance Rest Snap where
   setHeader nm v     = modifyResponse (Snap.setHeader (CI.mk . UTF8.fromString $ nm) (UTF8.fromString v))
   setResponseCode cd = modifyResponse (Snap.setResponseCode cd)
 
-toRestMethod :: Snap.Method -> Rest.Method
-toRestMethod Snap.GET    = Rest.GET
-toRestMethod Snap.POST   = Rest.POST
-toRestMethod Snap.PUT    = Rest.PUT
-toRestMethod Snap.DELETE = Rest.DELETE
-toRestMethod mthd        = Rest.Unknown (show mthd)
+toRestMethod :: Snap.Method -> Maybe Rest.Method
+toRestMethod Snap.GET    = Just Rest.GET
+toRestMethod Snap.POST   = Just Rest.POST
+toRestMethod Snap.PUT    = Just Rest.PUT
+toRestMethod Snap.DELETE = Just Rest.DELETE
+toRestMethod _           = Nothing

--- a/rest-types/rest-types.cabal
+++ b/rest-types/rest-types.cabal
@@ -25,6 +25,7 @@ library
     Rest.Types.Container.Resource
     Rest.Types.Error
     Rest.Types.Info
+    Rest.Types.Method
     Rest.Types.Range
     Rest.Types.ShowUrl
   build-depends:

--- a/rest-types/src/Rest/Types/Container/Resource.hs
+++ b/rest-types/src/Rest/Types/Container/Resource.hs
@@ -23,6 +23,7 @@ import Generics.Generic.Aeson
 import Generics.Regular (PF, deriveAll)
 import Generics.Regular.XmlPickler (gxpickle)
 import Rest.StringMap.HashMap.Strict (StringHashMap)
+import Rest.Types.Method
 import Text.XML.HXT.Arrow.Pickle
 import qualified Data.JSON.Schema.Combinators as Json
 
@@ -41,6 +42,7 @@ instance XmlPickler Value where
 
 data Resource = Resource
   { uri        :: String
+  , method     :: Method
   , headers    :: KeyValues
   , parameters :: KeyValues
   , input      :: String

--- a/rest-types/src/Rest/Types/Method.hs
+++ b/rest-types/src/Rest/Types/Method.hs
@@ -1,0 +1,5 @@
+module Rest.Types.Method (Method (..)) where
+
+
+data Method = GET | PUT | POST | DELETE
+  deriving (Show, Eq)

--- a/rest-types/src/Rest/Types/Method.hs
+++ b/rest-types/src/Rest/Types/Method.hs
@@ -1,5 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Rest.Types.Method (Method (..)) where
 
+import Control.Applicative
+import Data.Aeson (ToJSON (..), FromJSON (..))
+import Data.Aeson.Types (typeMismatch)
+import Data.Char (toLower)
+import Data.JSON.Schema (JSONSchema (..))
+import Text.XML.HXT.Arrow.Pickle
+import Text.XML.HXT.Arrow.Pickle.Schema
+import Text.XML.HXT.Arrow.Pickle.Xml
+
+import qualified Data.Aeson       as Json
+import qualified Data.JSON.Schema as Schema
+import qualified Data.Text        as Text
 
 data Method = GET | PUT | POST | DELETE
-  deriving (Show, Eq)
+  deriving (Show, Eq, Bounded, Enum)
+
+instance ToJSON     Method where
+  toJSON = toJSON . methodToString
+
+instance FromJSON   Method where
+  parseJSON (Json.String s) = case s of
+    "GET"    -> return GET
+    "PUT"    -> return PUT
+    "POST"   -> return POST
+    "DELETE" -> return DELETE
+    m -> fail $ "Unknown string when parsing method: " ++ Text.unpack m
+  parseJSON j = typeMismatch "String" j
+
+instance JSONSchema Method where
+  schema _ = Schema.Choice [ Schema.Constant (Json.String "GET")
+                           , Schema.Constant (Json.String "PUT")
+                           , Schema.Constant (Json.String "POST")
+                           , Schema.Constant (Json.String "DELETE")
+                           ]
+
+instance XmlPickler Method where
+  xpickle = PU
+    (\x -> appPickle (xpElem (methodToStringLC x) (xpickle :: PU ())) ())
+    (choices (map mkUnpickler enumAll))
+    (scAlts (map (\m -> scElem (methodToStringLC m) scEmpty) enumAll))
+
+mkUnpickler :: Method -> Unpickler Method
+mkUnpickler m = appUnPickle (xpWrap (const m, const ())
+                              (xpElem (methodToStringLC m)
+                                (xpickle :: PU ()))
+                            )
+
+choice :: Unpickler a -> Unpickler a -> Unpickler a
+choice x y = mchoice x pure y
+
+choices :: [Unpickler a] -> Unpickler a
+choices = foldr1 choice
+
+enumAll :: (Bounded a, Enum a) => [a]
+enumAll = [minBound .. maxBound]
+
+methodToString :: Method -> String
+methodToString GET    = "GET"
+methodToString PUT    = "PUT"
+methodToString POST   = "POST"
+methodToString DELETE = "DELETE"
+
+methodToStringLC :: Method -> String
+methodToStringLC = map toLower . methodToString

--- a/rest-wai/src/Rest/Driver/Wai.hs
+++ b/rest-wai/src/Rest/Driver/Wai.hs
@@ -53,11 +53,11 @@ toRestInput req =
        , body       = bs
 
        , method     = case requestMethod req of
-                        "GET"    -> Rest.GET
-                        "POST"   -> Rest.POST
-                        "PUT"    -> Rest.PUT
-                        "DELETE" -> Rest.DELETE
-                        other    -> Rest.Unknown (string other)
+                        "GET"    -> Just Rest.GET
+                        "POST"   -> Just Rest.POST
+                        "PUT"    -> Just Rest.PUT
+                        "DELETE" -> Just Rest.DELETE
+                        _        -> Nothing
 
        , paths      = text <$> filter (not . Text.null) (pathInfo req)
 


### PR DESCRIPTION
This changes the top level multi handler to be POST only. GET wasn't technically correct, and it's even less so on this branch, since this adds the possibility to do non-GET requests as part of the multi handler.

This is backwards compatibility breaking, and will be a major bump. However, I doubt it will break many things, since we haven't really advertised the top level multi handler.