### PR TITLE
Switch to ExceptT

### DIFF
--- a/rest-core/rest-core.cabal
+++ b/rest-core/rest-core.cabal
@@ -51,6 +51,7 @@ library
     , hxt-pickle-utils == 0.1.*
     , json-schema >= 0.6 && < 0.8
     , mtl >= 2.0 && < 2.3
+    , mtl-compat == 0.1.*
     , multipart >= 0.1.1 && < 0.2
     , random >= 1.0 && < 1.2
     , rest-stringmap == 0.2.*
@@ -74,6 +75,7 @@ test-suite rest-tests
     , HUnit == 1.2.*
     , bytestring >= 0.9 && < 0.11
     , mtl >= 2.0 && < 2.3
+    , mtl-compat == 0.1.*
     , rest-core
     , test-framework == 0.8.*
     , test-framework-hunit == 0.3.*

--- a/rest-core/src/Rest/Driver/Perform.hs
+++ b/rest-core/src/Rest/Driver/Perform.hs
@@ -334,7 +334,7 @@ tryOutputs try outputs = do
   rethrowLast $ (msum $ try outputs <$> formats) <|> unsupportedFormat formats
   where
     rethrowLast :: Monad m => ExceptT (Last DataError) m a -> ExceptT (Reason e) m a
-    rethrowLast = either (maybe (error "impossible") (throwError . OutputError) . getLast) return <=< lift . runExceptT
+    rethrowLast = either (maybe (error "Rest.Driver.Perform: ExceptT threw Last Nothing, this is a bug") (throwError . OutputError) . getLast) return <=< lift . runExceptT
 
 outputMultipart :: Rest m => [BodyPart] -> m UTF8.ByteString
 outputMultipart vs =

--- a/rest-core/src/Rest/Error.hs
+++ b/rest-core/src/Rest/Error.hs
@@ -19,7 +19,7 @@ module Rest.Error
   ) where
 
 import Control.Applicative
-import Control.Monad.Error
+import Control.Monad.Except
 
 import Rest.Types.Error
 
@@ -27,8 +27,8 @@ import Rest.Types.Error
 
 infixl 8 `mapE`
 
-mapE :: (Applicative m, Monad m) => (e -> e') -> ErrorT e m a -> ErrorT e' m a
-mapE f = mapErrorT (either (Left . f) Right <$>)
+mapE :: (Applicative m, Monad m) => (e -> e') -> ExceptT e m a -> ExceptT e' m a
+mapE f = mapExceptT (either (Left . f) Right <$>)
 
 orThrow :: MonadError e m => m (Maybe b) -> e -> m b
 orThrow a e = a >>= throwError e `maybe` return

--- a/rest-example/example-api/Api/Test.hs
+++ b/rest-example/example-api/Api/Test.hs
@@ -9,8 +9,8 @@
   #-}
 module Api.Test where
 
+import Control.Monad.Except
 import Control.Monad.Reader
-import Control.Monad.Trans.Error
 import Data.Aeson
 import Data.Data
 import Data.JSON.Schema

--- a/rest-example/example-api/Api/Test/DashedName.hs
+++ b/rest-example/example-api/Api/Test/DashedName.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Api.Test.DashedName (resource) where
 
-import Control.Monad.Error
+import Control.Monad.Except
 import Control.Monad.Reader
 import Rest
 import qualified Rest.Resource as R
@@ -22,5 +22,5 @@ resource = mkResourceReader
 remove :: Handler WithSiteSubscription
 remove = mkConstHandler id handler
   where
-    handler :: ErrorT Reason_ WithSiteSubscription ()
+    handler :: ExceptT Reason_ WithSiteSubscription ()
     handler = return ()

--- a/rest-example/example-api/Api/User.hs
+++ b/rest-example/example-api/Api/User.hs
@@ -2,7 +2,7 @@ module Api.User (resource) where
 
 import Control.Applicative ((<$>))
 import Control.Concurrent.STM (atomically, modifyTVar, readTVar)
-import Control.Monad.Error (ErrorT, throwError)
+import Control.Monad.Except (ExceptT, throwError)
 import Control.Monad.Reader (ReaderT, asks)
 import Control.Monad.Trans (liftIO)
 import Data.Set (Set)
@@ -36,7 +36,7 @@ resource = mkResourceReader
 list :: ListHandler BlogApi
 list = mkListing xmlJsonO handler
   where
-    handler :: Range -> ErrorT Reason_ BlogApi [UserInfo]
+    handler :: Range -> ExceptT Reason_ BlogApi [UserInfo]
     handler r = do
       usrs <- liftIO . atomically . readTVar =<< asks users
       return . map toUserInfo . take (count r) . drop (offset r) . Set.toList $ usrs
@@ -48,7 +48,7 @@ toUserInfo u = UserInfo { UserInfo.name = User.name u }
 create :: Handler BlogApi
 create = mkInputHandler (xmlJsonE . xmlJsonO . xmlJsonI) handler
   where
-    handler :: User -> ErrorT (Reason UserSignupError) BlogApi UserInfo
+    handler :: User -> ExceptT (Reason UserSignupError) BlogApi UserInfo
     handler usr = do
       usrs <- asks users
       merr <- liftIO . atomically $ do

--- a/rest-example/rest-example.cabal
+++ b/rest-example/rest-example.cabal
@@ -48,6 +48,7 @@ library
     , hxt == 9.3.*
     , json-schema >= 0.6 && < 0.8
     , mtl >= 2.0 && < 2.3
+    , mtl-compat == 0.1.*
     , regular == 0.3.*
     , regular-xmlpickler == 0.2.*
     , rest-core >= 0.33 && < 0.35
@@ -93,6 +94,7 @@ executable rest-example-happstack
         base >= 4.6 && < 4.8
       , happstack-server >= 7.1 && < 7.5
       , mtl >= 2.0 && < 2.3
+      , mtl-compat == 0.1.*
       , rest-core >= 0.33 && < 0.35
       , rest-example
       , rest-happstack == 0.2.*
@@ -109,6 +111,7 @@ executable rest-example-wai
     build-depends:
         base >= 4.6 && < 4.8
       , mtl >= 2.0 && < 2.3
+      , mtl-compat == 0.1.*
       , rest-core >= 0.33 && < 0.35
       , rest-example
       , rest-wai == 0.1.*
@@ -127,6 +130,7 @@ executable rest-example-snap
     build-depends:
         base >= 4.6 && < 4.8
       , mtl >= 2.0 && < 2.3
+      , mtl-compat == 0.1.*
       , rest-core >= 0.33 && < 0.35
       , rest-example
       , rest-snap == 0.1.*
@@ -145,6 +149,7 @@ executable rest-example-gen
     build-depends:
         base >= 4.6 && < 4.8
       , mtl >= 2.0 && < 2.3
+      , mtl-compat == 0.1.*
       , rest-core >= 0.33 && < 0.35
       , rest-example
       , rest-gen >= 0.14 && < 0.17

--- a/rest-types/rest-types.cabal
+++ b/rest-types/rest-types.cabal
@@ -37,6 +37,7 @@ library
     , hxt >= 9.2 && < 9.4
     , json-schema >= 0.6 && < 0.8
     , mtl >= 2.0 && < 2.3
+    , mtl-compat == 0.1.*
     , regular == 0.3.*
     , regular-xmlpickler == 0.2.*
     , rest-stringmap == 0.2.*

--- a/rest-types/src/Rest/Types/Error.hs
+++ b/rest-types/src/Rest/Types/Error.hs
@@ -26,7 +26,6 @@ module Rest.Types.Error
 import Data.Aeson hiding (Success)
 import Data.Foldable (Foldable)
 import Data.JSON.Schema (JSONSchema (..), gSchema)
-import Data.Monoid (Monoid (..))
 import Data.Traversable (Traversable)
 import Data.Typeable
 import GHC.Generics
@@ -48,10 +47,6 @@ data DataError
   | MissingField      String
   | UnsupportedFormat String
   deriving (Eq, Generic, Show)
-
-instance Monoid DataError where
-  mempty = ParseError ""
-  mappend _ b = b
 
 newtype DomainReason a = DomainReason { reason :: a }
   deriving (Eq, Generic, Functor, Foldable, Show, Traversable)


### PR DESCRIPTION
This fixes most of #78 

I replaced all usages of ErrorT, and removed unneeded Error instances.
Migration is easy for users so I think there's little benefit in keeping ErrorT anywhere.

I needed to add a Monoid instance for `DataError`. Any thoughts on what the definition should be?

I also could not upgrade rest-client (this does not prevent us from releasing this), it depends on https://github.com/ekmett/exceptions/pull/38 and possibly other libraries.

