### PR TITLE
Switch to generic-xmlpickler

### DIFF
--- a/rest-example/example-api/Api/Test.hs
+++ b/rest-example/example-api/Api/Test.hs
@@ -4,8 +4,6 @@
   , LambdaCase
   , OverloadedStrings
   , ScopedTypeVariables
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Api.Test where
 
@@ -17,8 +15,7 @@ import Data.JSON.Schema
 import Data.Text (Text)
 import GHC.Generics
 import Generics.Generic.Aeson
-import Generics.Regular
-import Generics.Regular.XmlPickler
+import Generics.XmlPickler
 import Text.XML.HXT.Arrow.Pickle
 
 import Rest
@@ -32,8 +29,6 @@ import qualified Api.Test.Err2 as E2
 type WithText = ReaderT Text BlogApi
 
 data Err = Err deriving (Generic, Show, Typeable)
-deriveAll ''Err "PFErr"
-type instance PF Err = PFErr
 instance ToJSON     Err where toJSON    = gtoJson
 instance FromJSON   Err where parseJSON = gparseJson
 instance JSONSchema Err where schema    = gSchema
@@ -43,8 +38,6 @@ instance ToResponseCode Err where
   toResponseCode _ = 400
 
 data Ok = Ok deriving (Generic, Show, Typeable)
-deriveAll ''Ok "PFOk"
-type instance PF Ok = PFOk
 instance XmlPickler Ok where xpickle = gxpickle
 instance ToJSON     Ok where toJSON    = gtoJson
 instance FromJSON   Ok where parseJSON = gparseJson

--- a/rest-example/example-api/Api/Test/Err2.hs
+++ b/rest-example/example-api/Api/Test/Err2.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , DeriveGeneric
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Api.Test.Err2 where
 
@@ -11,15 +9,12 @@ import Data.Data
 import Data.JSON.Schema
 import GHC.Generics
 import Generics.Generic.Aeson
-import Generics.Regular
-import Generics.Regular.XmlPickler
+import Generics.XmlPickler
 import Text.XML.HXT.Arrow.Pickle
 
 import Rest
 
 data Err = Err deriving (Generic, Show, Typeable)
-deriveAll ''Err "PFErr"
-type instance PF Err = PFErr
 instance ToJSON     Err where toJSON    = gtoJson
 instance FromJSON   Err where parseJSON = gparseJson
 instance JSONSchema Err where schema    = gSchema

--- a/rest-example/example-api/Type/Comment.hs
+++ b/rest-example/example-api/Type/Comment.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , DeriveGeneric
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Type.Comment (Comment (..)) where
 
@@ -12,8 +10,7 @@ import Data.Text (Text)
 import Data.Time
 import Data.Typeable
 import GHC.Generics
-import Generics.Regular
-import Generics.Regular.XmlPickler
+import Generics.XmlPickler
 import Text.XML.HXT.Arrow.Pickle
 
 import Type.Post ()
@@ -24,9 +21,6 @@ data Comment = Comment
   , createdTime :: UTCTime
   , content     :: Text
   } deriving (Eq, Generic, Ord, Show, Typeable)
-
-deriveAll ''Comment "PFComment"
-type instance PF Comment = PFComment
 
 instance XmlPickler Comment where xpickle = gxpickle
 instance JSONSchema Comment where schema = gSchema

--- a/rest-example/example-api/Type/CreatePost.hs
+++ b/rest-example/example-api/Type/CreatePost.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , DeriveGeneric
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Type.CreatePost where
 
@@ -11,8 +9,7 @@ import Data.JSON.Schema
 import Data.Text (Text)
 import Data.Typeable
 import GHC.Generics
-import Generics.Regular
-import Generics.Regular.XmlPickler
+import Generics.XmlPickler
 import Text.XML.HXT.Arrow.Pickle
 
 type Title = Text
@@ -21,9 +18,6 @@ data CreatePost = CreatePost
   { title   :: Title
   , content :: Text
   } deriving (Eq, Generic, Ord, Show, Typeable)
-
-deriveAll ''CreatePost "PFCreatePost"
-type instance PF CreatePost = PFCreatePost
 
 instance XmlPickler CreatePost where xpickle = gxpickle
 instance JSONSchema CreatePost where schema = gSchema

--- a/rest-example/example-api/Type/Post.hs
+++ b/rest-example/example-api/Type/Post.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , DeriveGeneric
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Type.Post where
 
@@ -13,8 +11,7 @@ import Data.Text (Text)
 import Data.Time (UTCTime)
 import Data.Typeable
 import GHC.Generics
-import Generics.Regular
-import Generics.Regular.XmlPickler
+import Generics.XmlPickler
 import Text.XML.HXT.Arrow.Pickle
 
 import qualified Type.User as User
@@ -29,9 +26,6 @@ data Post = Post
   , title       :: Title
   , content     :: Text
   } deriving (Eq, Generic, Ord, Show, Typeable)
-
-deriveAll ''Post "PFPost"
-type instance PF Post = PFPost
 
 instance XmlPickler Post where xpickle = gxpickle
 instance JSONSchema Post where schema = gSchema

--- a/rest-example/example-api/Type/PostError.hs
+++ b/rest-example/example-api/Type/PostError.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , DeriveGeneric
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Type.PostError where
 
@@ -10,16 +8,12 @@ import Data.Aeson
 import Data.JSON.Schema
 import Data.Typeable
 import GHC.Generics
-import Generics.Regular
-import Generics.Regular.XmlPickler
+import Generics.XmlPickler
 import Rest.Error
 import Text.XML.HXT.Arrow.Pickle
 
 data PostError = InvalidTitle | InvalidContent
   deriving (Eq, Generic, Ord, Show, Typeable)
-
-deriveAll ''PostError "PFPostError"
-type instance PF PostError = PFPostError
 
 instance XmlPickler PostError where xpickle = gxpickle
 instance JSONSchema PostError where schema = gSchema

--- a/rest-example/example-api/Type/User.hs
+++ b/rest-example/example-api/Type/User.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , DeriveGeneric
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Type.User where
 
@@ -11,8 +9,7 @@ import Data.JSON.Schema
 import Data.Text (Text)
 import Data.Typeable
 import GHC.Generics
-import Generics.Regular
-import Generics.Regular.XmlPickler
+import Generics.XmlPickler
 import Text.XML.HXT.Arrow.Pickle
 
 type Name = Text
@@ -22,9 +19,6 @@ data User = User
   { name     :: Name
   , password :: Password
   } deriving (Eq, Generic, Ord, Show, Typeable)
-
-deriveAll ''User "PFUser"
-type instance PF User = PFUser
 
 instance XmlPickler User where xpickle = gxpickle
 instance JSONSchema User where schema = gSchema

--- a/rest-example/example-api/Type/UserComment.hs
+++ b/rest-example/example-api/Type/UserComment.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , DeriveGeneric
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Type.UserComment where
 
@@ -11,8 +9,7 @@ import Data.JSON.Schema
 import Data.Text (Text)
 import Data.Typeable
 import GHC.Generics
-import Generics.Regular
-import Generics.Regular.XmlPickler
+import Generics.XmlPickler
 import Text.XML.HXT.Arrow.Pickle
 
 import Type.User (User)
@@ -21,9 +18,6 @@ data UserComment = UserComment
   { user    :: User
   , comment :: Text
   } deriving (Eq, Generic, Ord, Show, Typeable)
-
-deriveAll ''UserComment "PFUserComment"
-type instance PF UserComment = PFUserComment
 
 instance XmlPickler UserComment where xpickle = gxpickle
 instance JSONSchema UserComment where schema = gSchema

--- a/rest-example/example-api/Type/UserInfo.hs
+++ b/rest-example/example-api/Type/UserInfo.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , DeriveGeneric
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Type.UserInfo where
 
@@ -10,8 +8,7 @@ import Data.Aeson
 import Data.JSON.Schema
 import Data.Typeable
 import GHC.Generics
-import Generics.Regular
-import Generics.Regular.XmlPickler
+import Generics.XmlPickler
 import Text.XML.HXT.Arrow.Pickle
 
 import qualified Type.User as User
@@ -19,9 +16,6 @@ import qualified Type.User as User
 data UserInfo = UserInfo
   { name :: User.Name
   } deriving (Generic, Show, Typeable)
-
-deriveAll ''UserInfo "PFUserInfo"
-type instance PF UserInfo = PFUserInfo
 
 instance XmlPickler UserInfo where xpickle = gxpickle
 instance JSONSchema UserInfo where schema = gSchema

--- a/rest-example/example-api/Type/UserPost.hs
+++ b/rest-example/example-api/Type/UserPost.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , DeriveGeneric
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Type.UserPost where
 
@@ -10,8 +8,7 @@ import Data.Aeson
 import Data.JSON.Schema
 import Data.Typeable
 import GHC.Generics
-import Generics.Regular
-import Generics.Regular.XmlPickler
+import Generics.XmlPickler
 import Text.XML.HXT.Arrow.Pickle
 
 import Type.CreatePost (CreatePost)
@@ -19,9 +16,6 @@ import Type.User (User)
 
 data UserPost = UserPost { user :: User, post :: CreatePost }
   deriving (Eq, Generic, Ord, Show, Typeable)
-
-deriveAll ''UserPost "PFUserPost"
-type instance PF UserPost = PFUserPost
 
 instance XmlPickler UserPost where xpickle = gxpickle
 instance JSONSchema UserPost where schema = gSchema

--- a/rest-example/example-api/Type/UserSignupError.hs
+++ b/rest-example/example-api/Type/UserSignupError.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE
     DeriveDataTypeable
   , DeriveGeneric
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Type.UserSignupError where
 
@@ -10,16 +8,12 @@ import Data.Aeson
 import Data.JSON.Schema
 import Data.Typeable
 import GHC.Generics
-import Generics.Regular
-import Generics.Regular.XmlPickler
+import Generics.XmlPickler
 import Rest.Error
 import Text.XML.HXT.Arrow.Pickle
 
 data UserSignupError = InvalidPassword | InvalidUserName
   deriving (Eq, Generic, Ord, Show, Typeable)
-
-deriveAll ''UserSignupError "PFUserSignupError"
-type instance PF UserSignupError = PFUserSignupError
 
 instance XmlPickler UserSignupError where xpickle = gxpickle
 instance JSONSchema UserSignupError where schema = gSchema

--- a/rest-example/rest-example.cabal
+++ b/rest-example/rest-example.cabal
@@ -48,8 +48,7 @@ library
     , hxt == 9.3.*
     , json-schema >= 0.6 && < 0.8
     , mtl >= 2.0 && < 2.3
-    , regular == 0.3.*
-    , regular-xmlpickler == 0.2.*
+    , generic-xmlpickler == 0.2.*
     , rest-core == 0.35.*
     , safe >= 0.2 && < 0.4
     , transformers >= 0.2 && < 0.5

--- a/rest-types/rest-types.cabal
+++ b/rest-types/rest-types.cabal
@@ -37,8 +37,7 @@ library
     , hxt >= 9.2 && < 9.4
     , json-schema >= 0.6 && < 0.8
     , mtl >= 2.0 && < 2.3
-    , regular == 0.3.*
-    , regular-xmlpickler == 0.2.*
+    , generic-xmlpickler == 0.2.*
     , rest-stringmap == 0.2.*
     , text >= 0.11 && < 1.3
     , transformers >= 0.3 && < 0.5

--- a/rest-types/src/Rest/Types/Container.hs
+++ b/rest-types/src/Rest/Types/Container.hs
@@ -8,9 +8,7 @@
   , GADTs
   , ScopedTypeVariables
   , StandaloneDeriving
-  , TemplateHaskell
   , TupleSections
-  , TypeFamilies
   , UndecidableInstances
   #-}
 module Rest.Types.Container
@@ -25,8 +23,7 @@ import Data.JSON.Schema (JSONSchema (..), gSchema)
 import Data.Typeable
 import GHC.Generics
 import Generics.Generic.Aeson
-import Generics.Regular (PF, deriveAll)
-import Generics.Regular.XmlPickler (gxpickle)
+import Generics.XmlPickler (gxpickle)
 import Text.XML.HXT.Arrow.Pickle
 import Text.XML.HXT.Arrow.Pickle.Schema
 import Text.XML.HXT.Arrow.Pickle.Xml
@@ -39,9 +36,6 @@ data List a = List
   , count  :: Int
   , items  :: [a]
   } deriving (Generic, Show, Typeable)
-
-deriveAll ''List "PFList"
-type instance PF (List a) = PFList a
 
 instance XmlPickler a => XmlPickler (List a) where xpickle   = gxpickle
 instance ToJSON     a => ToJSON     (List a) where toJSON    = gtoJson

--- a/rest-types/src/Rest/Types/Container/Resource.hs
+++ b/rest-types/src/Rest/Types/Container/Resource.hs
@@ -4,8 +4,6 @@
   , EmptyDataDecls
   , GeneralizedNewtypeDeriving
   , StandaloneDeriving
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Rest.Types.Container.Resource
   ( Resource (..)
@@ -21,8 +19,7 @@ import Data.JSON.Schema (JSONSchema (..), gSchema)
 import Data.Typeable
 import GHC.Generics
 import Generics.Generic.Aeson
-import Generics.Regular (PF, deriveAll)
-import Generics.Regular.XmlPickler (gxpickle)
+import Generics.XmlPickler (gxpickle)
 import Rest.StringMap.HashMap.Strict (StringHashMap)
 import Rest.Types.Method
 import Text.XML.HXT.Arrow.Pickle
@@ -50,9 +47,6 @@ data Resource = Resource
   , input      :: String
   } deriving (Generic, Show, Typeable)
 
-deriveAll ''Resource "PFResource"
-type instance PF Resource = PFResource
-
 instance XmlPickler Resource where
   xpickle = gxpickle
 
@@ -63,9 +57,6 @@ instance JSONSchema Resource where schema    = gSchema
 -------------------------------------------------------------------------------
 
 newtype Resources = Resources [Resource] deriving (Generic, Typeable)
-
-deriveAll ''Resources "PFResources"
-type instance PF Resources = PFResources
 
 instance XmlPickler Resources where
   xpickle = gxpickle

--- a/rest-types/src/Rest/Types/Error.hs
+++ b/rest-types/src/Rest/Types/Error.hs
@@ -8,8 +8,6 @@
   , GADTs
   , ScopedTypeVariables
   , StandaloneDeriving
-  , TemplateHaskell
-  , TypeFamilies
   #-}
 module Rest.Types.Error
   ( DataError (..)
@@ -32,8 +30,7 @@ import Data.Traversable (Traversable)
 import Data.Typeable
 import GHC.Generics
 import Generics.Generic.Aeson
-import Generics.Regular (PF, deriveAll)
-import Generics.Regular.XmlPickler (gxpickle)
+import Generics.XmlPickler (gxpickle)
 import Text.XML.HXT.Arrow.Pickle
 import Text.XML.HXT.Arrow.Pickle.Schema
 import Text.XML.HXT.Arrow.Pickle.Xml
@@ -66,9 +63,6 @@ instance JSONSchema a => JSONSchema (DomainReason a) where
 
 data Status a b = Failure a | Success b
   deriving (Eq, Show, Generic, Typeable, Functor, Foldable, Traversable)
-
-deriveAll ''Status "PFStatus"
-type instance PF (Status a b) = PFStatus a b
 
 instance (XmlPickler a, XmlPickler b) => XmlPickler (Status a b) where
   xpickle = gxpickle
@@ -134,13 +128,7 @@ instance Monad Reason where
     Busy                          -> Busy
     Gone                          -> Gone
 
-deriveAll ''DataError "PFDataError"
-deriveAll ''Reason    "PFReason"
-
-type instance PF DataError  = PFDataError
-type instance PF (Reason e) = PFReason e
-
-instance XmlPickler DataError  where xpickle = gxpickle
+instance XmlPickler DataError where xpickle = gxpickle
 instance XmlPickler e => XmlPickler (Reason e) where xpickle = gxpickle
 
 instance ToJSON DataError where toJSON = gtoJson


### PR DESCRIPTION
This removes the regular dependency and stuffs.

Before merging this we may want to write tests and verify that generic-xmlpickler is compatible with regular-xmlpickler, perhaps by copying over the json-schema/generic-aeson tests. And we might as well combine it with another major release of rest packages since this doesn't add any functionality but is a breaking change.

