### PR TITLE
Simplify, generalize >|< and add >?<

### DIFF
--- a/rest-core/rest-core.cabal
+++ b/rest-core/rest-core.cabal
@@ -57,7 +57,6 @@ library
     , rest-stringmap == 0.2.*
     , rest-types == 1.13.*
     , safe >= 0.2 && < 0.4
-    , semigroups == 0.16.*
     , split >= 0.1 && < 0.3
     , text >= 0.11 && < 1.3
     , transformers >= 0.2 && < 0.5

--- a/rest-core/src/Rest/Error.hs
+++ b/rest-core/src/Rest/Error.hs
@@ -12,6 +12,7 @@ module Rest.Error
   , eitherToStatus
   , domainReason
   , (>|<)
+  , (>?<)
   ) where
 
 import Control.Applicative
@@ -46,3 +47,11 @@ infixl 3 >|<
 -- This prevents the need for a Semigroup or Monoid instance for the error type, which is necessary if using (<!>) or (<|>) respectively.
 (>|<) :: (Monad m) => ExceptT f m a -> ExceptT e m a -> ExceptT e m a
 ExceptT m >|< ExceptT n = ExceptT $ m >>= either (const n) (return . Right)
+
+infixl 3 >?<
+-- | Try to get a Just from Maybe computations (left to right), otherwise gives Nothing.
+-- This is the unwrapped version of <|> for MaybeT without a Functor constraint.
+-- Example: f >?< g `orThrow` NotFound.
+-- f >?< g `orThrow` e = (f `orThrow` e) >|< (g `orThrow` e)
+(>?<) :: Monad m => m (Maybe a) -> m (Maybe a) -> m (Maybe a)
+(>?<) m n = m >>= maybe n (return . Just)

--- a/rest-core/src/Rest/Error.hs
+++ b/rest-core/src/Rest/Error.hs
@@ -15,9 +15,7 @@ module Rest.Error
   ) where
 
 import Control.Applicative
-import Control.Monad.Error.Class
-import Control.Monad.Trans.Except
-import Data.Semigroup
+import Control.Monad.Except
 
 import Rest.Types.Error
 
@@ -46,11 +44,5 @@ domainReason = CustomReason . DomainReason
 infixl 3 >|<
 -- | Combine two ExceptT computations yielding the last error if both fail.
 -- This prevents the need for a Semigroup or Monoid instance for the error type, which is necessary if using (<!>) or (<|>) respectively.
-(>|<) :: (Applicative m, Monad m) => ExceptT e m a -> ExceptT e m a -> ExceptT e m a
-a >|< b = mapE getLast (mapE Last a <!> mapE Last b)
-  where
-    ExceptT m <!> ExceptT n = ExceptT $ do
-      v <- m
-      case v of
-        Left e -> fmap (either (Left . (<>) e) Right) n
-        Right x -> return (Right x)
+(>|<) :: (Monad m) => ExceptT f m a -> ExceptT e m a -> ExceptT e m a
+ExceptT m >|< ExceptT n = ExceptT $ m >>= either (const n) (return . Right)


### PR DESCRIPTION
Generalized the signature of `>|<`, the error in the first argument is never thrown so we can make that explicit.

`>?<` is useful in order to write ``f >?< g `orThrow` e`` where `f` and `g` give a `Maybe` result. I added this because I accidentally had ``f >|< g `orThrow` e`` which will never run `g` if `f` fails.

