### PR TITLE
Allow the use of the Google Closure compiler for minifying and optimizing generated javascript

### DIFF
--- a/rest-gen/src/Rest/Gen.hs
+++ b/rest-gen/src/Rest/Gen.hs
@@ -20,6 +20,7 @@ import Rest.Gen.JavaScript (mkJsApi)
 import Rest.Gen.Ruby (mkRbApi)
 import Rest.Gen.Types
 import Rest.Gen.Utils
+import Rest.Gen.JSCompiler
 
 generate :: Config -> String -> Api m -> [H.ModuleName] -> [H.ImportDecl] -> [(H.ModuleName, H.ModuleName)] -> IO ()
 generate config name api sources imports rewrites =
@@ -31,7 +32,7 @@ generate config name api sources imports rewrites =
             let context = DocsContext root ver (fromMaybe "./templates" (getSourceLocation config))
             writeDocs context r loc
             exitSuccess
-       Just MakeJS          -> mkJsApi (overModuleName (++ "Api") moduleName) (get apiPrivate config) ver r >>= toTarget config
+       Just MakeJS          -> mkJsApi (overModuleName (++ "Api") moduleName) (get apiPrivate config) ver r >>= withCompiler (get compiler config)>>= toTarget config
        Just MakeRb          -> mkRbApi (overModuleName (++ "Api") moduleName) (get apiPrivate config) ver r >>= toTarget config
        Just MakeHS          ->
          do loc <- getTargetDir config "./client"

--- a/rest-gen/src/Rest/Gen/Config.hs
+++ b/rest-gen/src/Rest/Gen/Config.hs
@@ -12,7 +12,7 @@ module Rest.Gen.Config
   , target
   , apiVersion
   , apiPrivate
-
+  , compiler
   , defaultConfig
   , parseLocation
   , options
@@ -26,6 +26,7 @@ import Control.Category
 import Data.Label
 import System.Console.GetOpt
 import System.Environment (getArgs)
+import Rest.Gen.JSCompiler
 
 data Action   = MakeDocs String | MakeJS | MakeRb | MakeHS
 data Location = Default | Stream | Location String
@@ -36,6 +37,7 @@ data Config = Config
   , _target     :: Location
   , _apiVersion :: String
   , _apiPrivate :: Bool
+  , _compiler :: Maybe Compiler
   }
 
 mkLabels [''Config]
@@ -47,11 +49,17 @@ defaultConfig = Config
   , _target     = Default
   , _apiVersion = "latest"
   , _apiPrivate = True
+  , _compiler   = Nothing
   }
 
 parseLocation :: String -> Location
 parseLocation "-" = Stream
 parseLocation s   = Location s
+
+parseCompiler "closure-simple" = Just ClosureSimple
+parseCompiler "closure-advanced" = Just ClosureAdvanced
+parseCompiler "whitespace" = Just ClosureWhitespace
+parseCompiler _ = Nothing
 
 options :: (a :-> Config) -> [OptDescr (a -> a)]
 options parent =
@@ -63,6 +71,7 @@ options parent =
   , Option ['t'] ["target"]        (ReqArg (set (target     . parent) . parseLocation) "LOCATION") "The target location for generation."
   , Option ['v'] ["version"]       (ReqArg (set (apiVersion . parent)) "VERSION") "The version of the API under generation. Default latest."
   , Option ['p'] ["hide-private"]  (NoArg  (set (apiPrivate . parent) False)) "Generate API for the public, hiding private resources. Not default."
+  , Option ['c'] ["compiler"]      (ReqArg (set (compiler   . parent) . parseCompiler) "COMPILER") "Choose a compiler for javascript.  \nDefaults to None. \nOptions are closure-simple, closure-advanced, whitespace and command. \nHas no effect if not generating javascript api"
   ]
 
 configFromArgs :: String -> IO Config

--- a/rest-gen/src/Rest/Gen/JSCompiler.hs
+++ b/rest-gen/src/Rest/Gen/JSCompiler.hs
@@ -1,0 +1,30 @@
+module Rest.Gen.JSCompiler (Compiler (..), withCompiler) where
+
+import qualified Network.HTTP                 as HTTP
+import qualified Network.HTTP.Base            as HTTP
+import qualified Network.URI                  as HTTP
+import Data.Functor
+import Data.Maybe
+
+
+import Code.Build
+
+data Compiler = ClosureWhitespace | ClosureSimple | ClosureAdvanced 
+
+withCompiler:: Maybe Compiler -> String -> IO String
+withCompiler Nothing = return . id
+withCompiler (Just compiler)  = useCompiler compiler
+
+useCompiler:: Compiler -> String -> IO String
+useCompiler ClosureSimple = closureCompile "SIMPLE_OPTIMIZATIONS"
+useCompiler ClosureAdvanced = closureCompile "ADVANCED_OPTIMIZATIONS"
+useCompiler ClosureWhitespace = closureCompile "WHITESPACE_ONLY"
+
+
+closureCompile:: String -> String -> IO String
+closureCompile compilationlevel code_str = HTTP.simpleHTTP (mkPostRequest) >>=  HTTP.getResponseBody
+  where payload = HTTP.urlEncodeVars [("js_code",code_str), ("compilation_level",compilationlevel),("output_format","text"),("output_info","compiled_code")]
+        headers = [HTTP.mkHeader HTTP.HdrContentType "application/x-www-form-urlencoded", HTTP.mkHeader HTTP.HdrContentLength (show $ length payload)]
+        url = HTTP.parseURI "http://www.closure-compiler.appspot.com/compile"
+        mkPostRequest = HTTP.Request {HTTP.rqURI = fromJust url, HTTP.rqMethod = HTTP.POST, HTTP.rqHeaders = headers, HTTP.rqBody = payload }
+


### PR DESCRIPTION
Fixes issue #122 