### PR TITLE
rest-gen refactorings and extensions

### DIFF
--- a/rest-core/src/Rest/Driver/Perform.hs
+++ b/rest-core/src/Rest/Driver/Perform.hs
@@ -277,7 +277,6 @@ contentType c = setHeader "Content-Type" $
     XmlFormat  -> "application/xml; charset=UTF-8"
     _          -> "text/plain; charset=UTF-8"
 
-
 validator :: forall v m e. Rest m => Outputs v -> ExceptT (Reason e) m ()
 validator = tryOutputs try
   where

--- a/rest-core/tests/Runner.hs
+++ b/rest-core/tests/Runner.hs
@@ -11,7 +11,7 @@ import Test.Framework (defaultMain)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit (Assertion, assertEqual, assertFailure)
 
-import qualified Data.HashMap.Strict   as H
+import qualified Data.HashMap.Strict as H
 
 import Rest.Api hiding (route)
 import Rest.Dictionary
@@ -206,5 +206,5 @@ allMethods = [GET, PUT, POST, DELETE]
 
 testAcceptHeaders :: Assertion
 testAcceptHeaders =
-  do fmt <- runRestM_ RestM.emptyInput { RestM.headers = H.singleton "Accept" "text/json" } accept
+  do fmt <- runRestM_ RestM.emptyInput { RestM.headers = H.singleton "Accept" "application/json" } accept
      assertEqual "Accept json format." [JsonFormat] fmt

--- a/rest-core/tests/Runner.hs
+++ b/rest-core/tests/Runner.hs
@@ -44,8 +44,8 @@ main = do
               , testCase "Root router is skipped." testRootRouter
               , testCase "Multi-PUT." testMultiPut
               , testCase "Multi-POST" testMultiPost
-              , testCase "Accept headers." testAcceptHeaders
-              , testCase "text/json accept header" testTextJsonHeader
+              , testCase "application/json accept header" testAppJsonAcceptHeader
+              , testCase "text/json accept header" testTextJsonAcceptHeader
               ]
 
 testListing :: Assertion
@@ -206,12 +206,12 @@ checkRouteSuccess method uri router =
 allMethods :: [Method]
 allMethods = [GET, PUT, POST, DELETE]
 
-testAcceptHeaders :: Assertion
-testAcceptHeaders =
+testAppJsonAcceptHeader :: Assertion
+testAppJsonAcceptHeader =
   do fmt <- runRestM_ RestM.emptyInput { RestM.headers = H.singleton "Accept" "application/json" } accept
-     assertEqual "Accept json format." [JsonFormat] fmt
+     assertEqual "Accept application/json format." [JsonFormat] fmt
 
-testTextJsonHeader :: Assertion
-testTextJsonHeader =
-  do fmt <- runRestM_ RestM.emptyInput { RestM.headers = H.singleton "Accept" "application/json" } accept
-     assertEqual "Accept json format." [JsonFormat] fmt
+testTextJsonAcceptHeader :: Assertion
+testTextJsonAcceptHeader =
+  do fmt <- runRestM_ RestM.emptyInput { RestM.headers = H.singleton "Accept" "text/json" } accept
+     assertEqual "Accept text/json format." [JsonFormat] fmt

--- a/rest-core/tests/Runner.hs
+++ b/rest-core/tests/Runner.hs
@@ -2,6 +2,7 @@
     OverloadedStrings
   , ScopedTypeVariables
   #-}
+module Main (main) where
 
 import Control.Applicative
 import Control.Monad
@@ -44,6 +45,7 @@ main = do
               , testCase "Multi-PUT." testMultiPut
               , testCase "Multi-POST" testMultiPost
               , testCase "Accept headers." testAcceptHeaders
+              , testCase "text/json accept header" testTextJsonHeader
               ]
 
 testListing :: Assertion
@@ -206,5 +208,10 @@ allMethods = [GET, PUT, POST, DELETE]
 
 testAcceptHeaders :: Assertion
 testAcceptHeaders =
+  do fmt <- runRestM_ RestM.emptyInput { RestM.headers = H.singleton "Accept" "application/json" } accept
+     assertEqual "Accept json format." [JsonFormat] fmt
+
+testTextJsonHeader :: Assertion
+testTextJsonHeader =
   do fmt <- runRestM_ RestM.emptyInput { RestM.headers = H.singleton "Accept" "application/json" } accept
      assertEqual "Accept json format." [JsonFormat] fmt

--- a/rest-example/generate/Main.hs
+++ b/rest-example/generate/Main.hs
@@ -19,3 +19,4 @@ main = do
     -- these are re-exported from an internal module they can be
     -- rewritten to something more stable.
     [(ModuleName "Data.Text.Internal", ModuleName "Data.Text")]
+    (const return)

--- a/rest-gen/files/Javascript/base.js
+++ b/rest-gen/files/Javascript/base.js
@@ -157,7 +157,8 @@ function nodeRequest (method, url, params, onSuccess, onError, contentType, acce
 
   function parse (response)
   {
-    if (acceptHeader.split(";").indexOf('text/json') >= 0)
+    var acceptHeaders = acceptHeader.split(";");
+    if (acceptHeaders.indexOf('text/json') >= 0 || acceptHeaders.indexOf('application/json') >= 0)
     {
       var r = response;
       try

--- a/rest-gen/src/Rest/Gen.hs
+++ b/rest-gen/src/Rest/Gen.hs
@@ -1,17 +1,11 @@
-module Rest.Gen
-  ( generate
-  ) where
+module Rest.Gen (generate) where
 
 import Data.Char
-import Data.Foldable
 import Data.Label
 import Data.Maybe
-import System.Directory
 import System.Exit
-import System.Process
-import qualified Language.Haskell.Exts.Syntax as H
 
-import Rest.Api (Api, Some1 (..), withVersion)
+import Rest.Api (Api, Router, Some1 (..), Version, withVersion)
 
 import Rest.Gen.Config
 import Rest.Gen.Docs (DocsContext (DocsContext), writeDocs)
@@ -20,51 +14,74 @@ import Rest.Gen.JavaScript (mkJsApi)
 import Rest.Gen.Ruby (mkRbApi)
 import Rest.Gen.Types
 import Rest.Gen.Utils
+import qualified Rest.Gen.Docs    as DCtx (DocsContext (..))
+import qualified Rest.Gen.Haskell as HCtx (HaskellContext (..))
 
-generate :: Config -> String -> Api m -> [H.ModuleName] -> [H.ImportDecl] -> [(H.ModuleName, H.ModuleName)] -> IO ()
+generate :: Config -> String -> Api m -> [ModuleName] -> [ImportDecl] -> [(ModuleName, ModuleName)] -> IO ()
 generate config name api sources imports rewrites =
   withVersion (get apiVersion config) api (putStrLn "Could not find api version" >> exitFailure) $ \ver (Some1 r) ->
      case get action config of
-       Just (MakeDocs root) ->
-         do loc <- getTargetDir config "./docs"
-            setupTargetDir config loc
-            let context = DocsContext root ver (fromMaybe "./templates" (getSourceLocation config))
-            writeDocs context r loc
-            exitSuccess
-       Just MakeJS          -> mkJsApi (overModuleName (++ "Api") moduleName) (get apiPrivate config) ver r >>= toTarget config
-       Just MakeRb          -> mkRbApi (overModuleName (++ "Api") moduleName) (get apiPrivate config) ver r >>= toTarget config
-       Just MakeHS          ->
-         do loc <- getTargetDir config "./client"
-            setupTargetDir config loc
-            let context = HaskellContext ver loc (packageName ++ "-client") (get apiPrivate config) sources imports rewrites [unModuleName moduleName, "Client"]
-            mkHsApi context r
-            exitSuccess
+       Just (MakeDocs root) -> makeDocs config ver r root >> exitSuccess
+       Just MakeJS          -> makeJS config ver r moduleName
+       Just MakeRb          -> makeRb config ver r moduleName
+       Just MakeHS          -> makeHS config ver r moduleName packageName sources imports rewrites >> exitSuccess
        Nothing              -> return ()
   where
     packageName = map toLower name
-    moduleName  = H.ModuleName $ upFirst packageName
+    moduleName  = ModuleName $ upFirst packageName
+
+makeDocs :: Config -> Version -> Router m s -> String -> IO ()
+makeDocs config ver r rootUrl = do
+  targetDir <- getTargetDir config "./docs"
+  writeDocs (context targetDir) r
+    where
+      context targetDir = DocsContext
+        { DCtx.rootUrl        = rootUrl
+        , DCtx.contextVersion = ver
+        , DCtx.templates      = "./templates" `fromMaybe` getSourceLocation config
+        , DCtx.targetDir      = targetDir
+        , DCtx.sourceDir      = getSourceLocation config
+        }
+
+makeJS :: Config -> Version -> Router m s -> ModuleName -> IO ()
+makeJS config ver r moduleName = mkJsApi moduleName (get apiPrivate config) ver r >>= toTarget config
+
+makeRb ::  Config -> Version -> Router m s -> ModuleName -> IO ()
+makeRb config ver r moduleName = mkRbApi moduleName (get apiPrivate config) ver r >>= toTarget config
+
+makeHS :: Config -> Version -> Router m s -> ModuleName -> String -> [ModuleName] -> [ImportDecl] -> [(ModuleName, ModuleName)] -> IO ()
+makeHS config ver r moduleName packageName sources imports rewrites = do
+  targetPath <- getTargetDir config "./client"
+  mkHsApi (context targetPath (getSourceLocation config)) r
+  where
+    context tp sourceDir = HaskellContext
+      { HCtx.apiVersion     = ver
+      , HCtx.targetPath     = tp
+      , HCtx.wrapperName    = packageName ++ "-client"
+      , HCtx.includePrivate = get apiPrivate config
+      , HCtx.sources        = sources
+      , HCtx.imports        = imports
+      , HCtx.rewrites       = rewrites
+      , HCtx.namespace      = [unModuleName moduleName, "Client"]
+      , HCtx.sourceDir      = sourceDir
+      }
 
 getTargetDir :: Config -> String -> IO String
 getTargetDir config str =
   case get target config of
-    Stream     -> putStrLn ("Cannot generate documentation to stdOut, generating to " ++ str) >> return str
-    Default    -> putStrLn ("Generating to " ++ str) >> return str
-    Location d -> putStrLn ("Generating to " ++ d) >> return d
-
-setupTargetDir :: Config -> String -> IO ()
-setupTargetDir config t =
-  do createDirectoryIfMissing True t
-     forM_ (getSourceLocation config) $ \s -> system $ "cp -rf " ++ s ++ " " ++ t
+    Stream     -> putStrLn ("Cannot generate file tree to stdOut, generating to " ++ str) >> return str
+    Default    -> putStrLn ("Generating to " ++ str)                                      >> return str
+    Location d -> putStrLn ("Generating to " ++ d)                                        >> return d
 
 toTarget :: Config -> String -> IO ()
-toTarget config code =
-  do let outf =
-           case get target config of
-             Stream     -> putStrLn
-             Default    -> putStrLn
-             Location l -> writeFile l
-     outf code
-     exitSuccess
+toTarget config code = do
+   outf code
+   exitSuccess
+  where
+    outf = case get target config of
+      Stream     -> putStrLn
+      Default    -> putStrLn
+      Location l -> writeFile l
 
 getSourceLocation :: Config -> Maybe String
 getSourceLocation config =

--- a/rest-gen/src/Rest/Gen.hs
+++ b/rest-gen/src/Rest/Gen.hs
@@ -61,28 +61,28 @@ runGenerate config name api sources imports rewrites postProc =
   where
     m :: Version -> Some1 (Router m) -> IO Result
     m ver (Some1 r) = case get action config of
-      Just (MakeDocs root) -> generateDocs       config ver r postProc root
-      Just MakeJS          -> generateJavaScript config ver r postProc moduleName
-      Just MakeRb          -> generateRuby       config ver r postProc moduleName
-      Just MakeHS          -> generateHaskell    config ver r postProc moduleName packageName sources imports rewrites
+      Just (MakeDocs root) -> generateDocs       config ver r (postProc HtmlFile      ) root
+      Just MakeJS          -> generateJavaScript config ver r (postProc JavaScriptFile) moduleName
+      Just MakeRb          -> generateRuby       config ver r (postProc RubyFile      ) moduleName
+      Just MakeHS          -> generateHaskell    config ver r (postProc HaskellFile   ) moduleName packageName sources imports rewrites
       Nothing              -> return $ Error NoOp
     packageName = map toLower name
     moduleName  = ModuleName $ upFirst packageName
 
-generateJavaScript :: Config -> Version -> Router m s -> (FileType -> String -> IO String) -> ModuleName -> IO Result
+generateJavaScript :: Config -> Version -> Router m s -> (String -> IO String) -> ModuleName -> IO Result
 generateJavaScript config ver r postProc moduleName = do
-  file <- postProc JavaScriptFile =<< mkJsApi (overModuleName (++ "Api") moduleName) (get apiPrivate config) ver r
+  file <- postProc =<< mkJsApi (overModuleName (++ "Api") moduleName) (get apiPrivate config) ver r
   toTarget config file
 
-generateRuby ::  Config -> Version -> Router m s -> (FileType -> String -> IO String) -> ModuleName -> IO Result
+generateRuby ::  Config -> Version -> Router m s -> (String -> IO String) -> ModuleName -> IO Result
 generateRuby config ver r postProc moduleName = do
-  file <- postProc RubyFile =<< mkRbApi (overModuleName (++ "Api") moduleName) (get apiPrivate config) ver r
+  file <- postProc =<< mkRbApi (overModuleName (++ "Api") moduleName) (get apiPrivate config) ver r
   toTarget config file
 
-generateDocs :: Config -> Version -> Router m s -> (FileType -> String -> IO String) -> String -> IO Result
+generateDocs :: Config -> Version -> Router m s -> (String -> IO String) -> String -> IO Result
 generateDocs config ver r postProc rootUrl = do
   targetDir <- getTargetDir config "./docs"
-  writeDocs (context targetDir) (postProc HtmlFile) r
+  writeDocs (context targetDir) postProc r
   return $ FileOut targetDir
     where
       context targetDir = DocsContext
@@ -93,10 +93,10 @@ generateDocs config ver r postProc rootUrl = do
         , DCtx.sourceDir      = getSourceLocation config
         }
 
-generateHaskell :: Config -> Version -> Router m s -> (FileType -> String -> IO String) -> ModuleName -> String -> [ModuleName] -> [ImportDecl] -> [(ModuleName, ModuleName)] -> IO Result
+generateHaskell :: Config -> Version -> Router m s -> (String -> IO String) -> ModuleName -> String -> [ModuleName] -> [ImportDecl] -> [(ModuleName, ModuleName)] -> IO Result
 generateHaskell config ver r postProc moduleName packageName sources imports rewrites = do
   targetPath <- getTargetDir config "./client"
-  mkHsApi (context targetPath (getSourceLocation config)) (postProc HaskellFile) r
+  mkHsApi (context targetPath (getSourceLocation config)) postProc r
   return $ FileOut targetPath
   where
     context tp sourceDir = HaskellContext

--- a/rest-gen/src/Rest/Gen.hs
+++ b/rest-gen/src/Rest/Gen.hs
@@ -82,15 +82,13 @@ generateRuby config ver r postProc moduleName = do
 generateDocs :: Config -> Version -> Router m s -> (String -> IO String) -> String -> IO Result
 generateDocs config ver r postProc rootUrl = do
   targetDir <- getTargetDir config "./docs"
-  writeDocs (context targetDir) postProc r
+  writeDocs (getSourceLocation config) targetDir context postProc r
   return $ FileOut targetDir
     where
-      context targetDir = DocsContext
+      context = DocsContext
         { DCtx.rootUrl        = rootUrl
         , DCtx.contextVersion = ver
         , DCtx.templates      = "./templates" `fromMaybe` getSourceLocation config
-        , DCtx.targetDir      = targetDir
-        , DCtx.sourceDir      = getSourceLocation config
         }
 
 generateHaskell :: Config -> Version -> Router m s -> (String -> IO String) -> ModuleName -> String -> [ModuleName] -> [ImportDecl] -> [(ModuleName, ModuleName)] -> IO Result

--- a/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
+++ b/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
@@ -190,7 +190,7 @@ dataTypeToAcceptHeader :: DataType -> String
 dataTypeToAcceptHeader = \case
   String -> "text/plain"
   XML    -> "text/xml"
-  JSON   -> "text/json"
+  JSON   -> "application/json"
   File   -> "application/octet-stream"
   Other  -> "text/plain"
 

--- a/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
+++ b/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
@@ -12,7 +12,12 @@ module Rest.Gen.Base.ActionInfo
   , ActionInfo (..)
   , ActionType (..)
   , ActionTarget (..)
+
   , DataType (..)
+  , dataTypesToAcceptHeader
+  , dataTypeToAcceptHeader
+  , dataTypeString
+
   , ResourceId
   , accessLink
   , accessors
@@ -34,7 +39,6 @@ module Rest.Gen.Base.ActionInfo
 
   , ResponseType (..)
   , responseAcceptType
-  , dataTypesToAcceptHeader
   , chooseResponseType
 
   , isAccessor
@@ -98,7 +102,34 @@ data ActionType = Retrieve | Create | Delete | DeleteMany | List | Update | Upda
 
 data ActionTarget = Self | Any deriving (Show, Eq)
 
-data DataType = String | XML | JSON | File | Other deriving (Show, Eq)
+data DataType = String | XML | JSON | File | Other
+  deriving (Show, Eq)
+
+dataTypeString :: DataType -> String
+dataTypeString = \case
+    String -> "text"
+    XML    -> "xml"
+    JSON   -> "json"
+    File   -> "file"
+    Other  -> "text"
+
+-- | First argument is the default accept header to use if there is no
+-- output or errors, must be XML or JSON.
+dataTypesToAcceptHeader :: DataType -> [DataType] -> String
+dataTypesToAcceptHeader def = \case
+  [] -> dataTypeToAcceptHeader def
+  xs -> intercalate "," . map dataTypeToAcceptHeader . (xs ++) $
+          if null (intersect xs [XML,JSON])
+            then [def]
+            else []
+
+dataTypeToAcceptHeader :: DataType -> String
+dataTypeToAcceptHeader = \case
+  String -> "text/plain"
+  XML    -> "text/xml"
+  JSON   -> "application/json"
+  File   -> "application/octet-stream"
+  Other  -> "text/plain"
 
 -- | Core information about the type of the input/output
 data DataDesc = DataDesc
@@ -175,24 +206,6 @@ responseAcceptType (ResponseType e o) = typs
       where
         f :: Maybe DataDesc -> [DataType]
         f = maybeToList . fmap (L.get dataType)
-
--- | First argument is the default accept header to use if there is no
--- output or errors, must be XML or JSON.
-dataTypesToAcceptHeader :: DataType -> [DataType] -> String
-dataTypesToAcceptHeader def = \case
-  [] -> dataTypeToAcceptHeader def
-  xs -> intercalate "," . map dataTypeToAcceptHeader . (xs ++) $
-          if null (intersect xs [XML,JSON])
-            then [def]
-            else []
-
-dataTypeToAcceptHeader :: DataType -> String
-dataTypeToAcceptHeader = \case
-  String -> "text/plain"
-  XML    -> "text/xml"
-  JSON   -> "application/json"
-  File   -> "application/octet-stream"
-  Other  -> "text/plain"
 
 chooseResponseType :: ActionInfo -> ResponseType
 chooseResponseType ai = case (NList.nonEmpty $ outputs ai, NList.nonEmpty $ errors ai) of

--- a/rest-gen/src/Rest/Gen/Docs.hs
+++ b/rest-gen/src/Rest/Gen/Docs.hs
@@ -46,20 +46,18 @@ data DocsContext = DocsContext
   { rootUrl        :: String
   , contextVersion :: Version
   , templates      :: String
-  , targetDir      :: FilePath
-  , sourceDir      :: Maybe FilePath
   } deriving (Eq, Show)
 
-writeDocs :: DocsContext -> (String -> IO String) -> Router m s -> IO ()
-writeDocs ctx postProc router = do
-  setupTargetDir (sourceDir ctx) (targetDir ctx)
+writeDocs :: Maybe FilePath -> FilePath -> DocsContext -> (String -> IO String) -> Router m s -> IO ()
+writeDocs sourceDir targetDir ctx postProc router = do
+  setupTargetDir sourceDir targetDir
   let tree = apiSubtrees router
-  mkAllResources ctx tree >>= postProc >>= writeIndex (targetDir ctx)
-  forM_ (allSubResources tree) $ writeSingleResource ctx postProc
+  mkAllResources ctx tree >>= postProc >>= writeIndex targetDir
+  forM_ (allSubResources tree) $ writeSingleResource targetDir ctx postProc
 
-writeSingleResource :: DocsContext -> (String -> IO String) -> ApiResource -> IO ()
-writeSingleResource ctx postProc r = do
-  let dir = targetDir ctx </> intercalate "/" (resId r)
+writeSingleResource :: FilePath -> DocsContext -> (String -> IO String) -> ApiResource -> IO ()
+writeSingleResource targetDir ctx postProc r = do
+  let dir = targetDir </> intercalate "/" (resId r)
   mkSingleResource ctx r >>= postProc >>= writeIndex dir
 
 writeIndex :: FilePath -> String -> IO ()

--- a/rest-gen/src/Rest/Gen/Docs.hs
+++ b/rest-gen/src/Rest/Gen/Docs.hs
@@ -47,14 +47,16 @@ data DocsContext = DocsContext
   { rootUrl        :: String
   , contextVersion :: Version
   , templates      :: String
+  , targetDir      :: FilePath
+  , sourceDir      :: Maybe FilePath
   } deriving (Eq, Show)
 
-writeDocs :: DocsContext -> Router m s -> String -> IO ()
-writeDocs context router loc =
-  do createDirectoryIfMissing True loc
-     let tree = apiSubtrees router
-     mkAllResources context tree >>= writeFile (loc </> "index.html")
-     mapM_ (writeSingleResource context loc) $ allSubResources tree
+writeDocs :: DocsContext -> Router m s -> IO ()
+writeDocs context router = do
+  setupTargetDir (sourceDir context) (targetDir context)
+  let tree = apiSubtrees router
+  mkAllResources context tree >>= writeFile (targetDir context </> "index.html")
+  mapM_ (writeSingleResource context (targetDir context)) $ allSubResources tree
 
 writeSingleResource :: DocsContext -> String -> ApiResource -> IO ()
 writeSingleResource ctx loc r =

--- a/rest-gen/src/Rest/Gen/Haskell.hs
+++ b/rest-gen/src/Rest/Gen/Haskell.hs
@@ -55,13 +55,15 @@ data HaskellContext =
     , imports        :: [H.ImportDecl]
     , rewrites       :: [(H.ModuleName, H.ModuleName)]
     , namespace      :: [String]
+    , sourceDir      :: Maybe FilePath
     }
 
 mkHsApi :: HaskellContext -> Router m s -> IO ()
-mkHsApi ctx r =
-  do let tree = sortTree . (if includePrivate ctx then id else noPrivate) . apiSubtrees $ r
-     mkCabalFile ctx tree
-     mapM_ (writeRes ctx) $ allSubTrees tree
+mkHsApi ctx r = do
+  setupTargetDir (sourceDir ctx) (targetPath ctx)
+  let tree = sortTree . (if includePrivate ctx then id else noPrivate) . apiSubtrees $ r
+  mkCabalFile ctx tree
+  mapM_ (writeRes ctx) $ allSubTrees tree
 
 mkCabalFile :: HaskellContext -> ApiResource -> IO ()
 mkCabalFile ctx tree =

--- a/rest-gen/src/Rest/Gen/Haskell.hs
+++ b/rest-gen/src/Rest/Gen/Haskell.hs
@@ -373,7 +373,7 @@ inputInfo dsc =
     String -> InputInfo [] (haskellStringType) "text/plain" "fromString"
     -- TODO fromJusts
     XML    -> InputInfo (L.get haskellModules dsc) (L.get haskellType dsc) "text/xml" "toXML"
-    JSON   -> InputInfo (L.get haskellModules dsc) (L.get haskellType dsc) "text/json" "toJSON"
+    JSON   -> InputInfo (L.get haskellModules dsc) (L.get haskellType dsc) "application/json" "toJSON"
     File   -> InputInfo [] haskellByteStringType "application/octet-stream" "id"
     Other  -> InputInfo [] haskellByteStringType "text/plain" "id"
 

--- a/rest-gen/src/Rest/Gen/JavaScript.hs
+++ b/rest-gen/src/Rest/Gen/JavaScript.hs
@@ -137,10 +137,11 @@ jsId []       = ""
 jsId (x : xs) = x ++ concatMap upFirst xs
 
 mkType :: DataType -> (String, String, Code -> Code)
-mkType dt =
-  case dt of
-    String -> ("text", "text/plain", id)
-    XML    -> ("xml" , "text/xml", id)
-    JSON   -> ("json", "application/json", call "JSON.stringify")
-    File   -> ("file", "application/octet-stream", id)
-    Other  -> ("text", "text/plain", id)
+mkType dt = (dataTypeString dt, dataTypeToAcceptHeader dt, fn)
+  where
+    fn = case dt of
+      String -> id
+      XML    -> id
+      JSON   -> call "JSON.stringify"
+      File   -> id
+      Other  -> id

--- a/rest-gen/src/Rest/Gen/JavaScript.hs
+++ b/rest-gen/src/Rest/Gen/JavaScript.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE
-    ScopedTypeVariables
-  , ViewPatterns
-  #-}
 module Rest.Gen.JavaScript (mkJsApi) where
 
 import Prelude hiding ((.))
@@ -21,7 +17,7 @@ import Rest.Gen.Types
 import Rest.Gen.Utils
 
 mkJsApi :: ModuleName -> Bool -> Version -> Router m s -> IO String
-mkJsApi (overModuleName (++ "Api") -> ns) priv ver r =
+mkJsApi ns priv ver r =
   do prelude <- liftM (render . setManyAttrib attrs . newSTMP) (readContent "Javascript/base.js")
      let cod = showCode $ mkStack
                 [ unModuleName ns ++ ".prototype.version" .=. string (show ver)

--- a/rest-gen/src/Rest/Gen/JavaScript.hs
+++ b/rest-gen/src/Rest/Gen/JavaScript.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE
+    ScopedTypeVariables
+  , ViewPatterns
+  #-}
 module Rest.Gen.JavaScript (mkJsApi) where
 
 import Prelude hiding ((.))
@@ -7,9 +10,8 @@ import Control.Category ((.))
 import Control.Monad
 import Data.Maybe
 import Text.StringTemplate
-import qualified Data.Label.Total             as L
-import qualified Data.List.NonEmpty           as NList
-import qualified Language.Haskell.Exts.Syntax as H
+import qualified Data.Label.Total   as L
+import qualified Data.List.NonEmpty as NList
 
 import Code.Build
 import Code.Build.JavaScript
@@ -18,15 +20,16 @@ import Rest.Gen.Base
 import Rest.Gen.Types
 import Rest.Gen.Utils
 
-mkJsApi :: H.ModuleName -> Bool -> Version -> Router m s -> IO String
-mkJsApi ns priv ver r =
+mkJsApi :: ModuleName -> Bool -> Version -> Router m s -> IO String
+mkJsApi (overModuleName (++ "Api") -> ns) priv ver r =
   do prelude <- liftM (render . setManyAttrib attrs . newSTMP) (readContent "Javascript/base.js")
      let cod = showCode $ mkStack
                 [ unModuleName ns ++ ".prototype.version" .=. string (show ver)
                 , mkJsCode (unModuleName ns) priv r
                 ]
      return $ mkJsModule (prelude ++ cod)
-  where attrs = [("apinamespace", unModuleName ns), ("dollar", "$")]
+  where
+    attrs = [("apinamespace", unModuleName ns), ("dollar", "$")]
 
 mkJsModule :: String -> String
 mkJsModule content = "(function (window) {\n\n" ++ content ++ "\n\n})(this);"

--- a/rest-gen/src/Rest/Gen/JavaScript.hs
+++ b/rest-gen/src/Rest/Gen/JavaScript.hs
@@ -141,6 +141,6 @@ mkType dt =
   case dt of
     String -> ("text", "text/plain", id)
     XML    -> ("xml" , "text/xml", id)
-    JSON   -> ("json", "text/json", call "JSON.stringify")
+    JSON   -> ("json", "application/json", call "JSON.stringify")
     File   -> ("file", "application/octet-stream", id)
     Other  -> ("text", "text/plain", id)

--- a/rest-gen/src/Rest/Gen/Ruby.hs
+++ b/rest-gen/src/Rest/Gen/Ruby.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE
-    ScopedTypeVariables
-  , ViewPatterns
-  #-}
 module Rest.Gen.Ruby (mkRbApi) where
 
 import Prelude hiding ((.))
@@ -22,7 +18,7 @@ import Rest.Gen.Types
 import Rest.Gen.Utils
 
 mkRbApi :: ModuleName -> Bool -> Version -> Router m s -> IO String
-mkRbApi (overModuleName (++ "Api") -> ns) priv ver r =
+mkRbApi ns priv ver r =
   do rawPrelude <- readContent "Ruby/base.rb"
      let prelude = replace "SilkApi" (unModuleName ns) rawPrelude
      let cod = showCode . mkRb (unModuleName ns) ver . sortTree . (if priv then id else noPrivate) . apiSubtrees $ r

--- a/rest-gen/src/Rest/Gen/Ruby.hs
+++ b/rest-gen/src/Rest/Gen/Ruby.hs
@@ -149,6 +149,6 @@ mkType dt =
   case dt of
     String -> ("data", "text/plain", id)
     XML    -> ("xml" , "text/xml", (<+> ".to_s"))
-    JSON   -> ("json", "text/json", call "mkJson")
+    JSON   -> ("json", "application/json", call "mkJson")
     File   -> ("file", "application/octet-stream", id)
     Other  -> ("data", "text/plain", id)

--- a/rest-gen/src/Rest/Gen/Ruby.hs
+++ b/rest-gen/src/Rest/Gen/Ruby.hs
@@ -145,10 +145,11 @@ accessorName :: ResourceId -> String
 accessorName = concatMap upFirst . ("Access":) . concatMap cleanName
 
 mkType :: DataType -> (String, String, Code -> Code)
-mkType dt =
-  case dt of
-    String -> ("data", "text/plain", id)
-    XML    -> ("xml" , "text/xml", (<+> ".to_s"))
-    JSON   -> ("json", "application/json", call "mkJson")
-    File   -> ("file", "application/octet-stream", id)
-    Other  -> ("data", "text/plain", id)
+mkType dt = (dataTypeString dt, dataTypeToAcceptHeader dt, fn)
+  where
+    fn = case dt of
+      String -> id
+      XML    -> (<+> ".to_s")
+      JSON   -> call "mkJson"
+      File   -> id
+      Other  -> id

--- a/rest-gen/src/Rest/Gen/Ruby.hs
+++ b/rest-gen/src/Rest/Gen/Ruby.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE
+    ScopedTypeVariables
+  , ViewPatterns
+  #-}
 module Rest.Gen.Ruby (mkRbApi) where
 
 import Prelude hiding ((.))
@@ -8,9 +11,8 @@ import Data.Char
 import Data.List
 import Data.List.Split (splitOn)
 import Data.Maybe
-import qualified Data.Label.Total             as L
-import qualified Data.List.NonEmpty           as NList
-import qualified Language.Haskell.Exts.Syntax as H
+import qualified Data.Label.Total   as L
+import qualified Data.List.NonEmpty as NList
 
 import Code.Build
 import Code.Build.Ruby
@@ -19,8 +21,8 @@ import Rest.Gen.Base
 import Rest.Gen.Types
 import Rest.Gen.Utils
 
-mkRbApi :: H.ModuleName -> Bool -> Version -> Router m s -> IO String
-mkRbApi ns priv ver r =
+mkRbApi :: ModuleName -> Bool -> Version -> Router m s -> IO String
+mkRbApi (overModuleName (++ "Api") -> ns) priv ver r =
   do rawPrelude <- readContent "Ruby/base.rb"
      let prelude = replace "SilkApi" (unModuleName ns) rawPrelude
      let cod = showCode . mkRb (unModuleName ns) ver . sortTree . (if priv then id else noPrivate) . apiSubtrees $ r

--- a/rest-gen/src/Rest/Gen/Utils.hs
+++ b/rest-gen/src/Rest/Gen/Utils.hs
@@ -7,9 +7,18 @@ module Rest.Gen.Utils
   , upFirst
   , downFirst
   , mapHead
+  , setupTargetDir
   ) where
 
+import Prelude hiding (foldr)
+
 import Data.Char
+import Data.Foldable
+import Data.List.Split
+import System.Directory
+import System.FilePath
+import System.Process
+import Text.StringTemplate
 
 import Paths_rest_gen (getDataFileName)
 
@@ -41,3 +50,8 @@ downFirst = mapHead toLower
 mapHead :: (a -> a) -> [a] -> [a]
 mapHead _ [] = []
 mapHead f (x : xs) = f x : xs
+
+setupTargetDir :: Maybe FilePath -> FilePath -> IO ()
+setupTargetDir msource targetDir = do
+  createDirectoryIfMissing True targetDir
+  forM_ msource $ \source -> system $ "cp -rf " ++ source ++ " " ++ targetDir

--- a/rest-gen/src/Rest/Gen/Utils.hs
+++ b/rest-gen/src/Rest/Gen/Utils.hs
@@ -14,11 +14,8 @@ import Prelude hiding (foldr)
 
 import Data.Char
 import Data.Foldable
-import Data.List.Split
 import System.Directory
-import System.FilePath
 import System.Process
-import Text.StringTemplate
 
 import Paths_rest_gen (getDataFileName)
 

--- a/rest-happstack/src/Rest/Driver/Happstack/Docs.hs
+++ b/rest-happstack/src/Rest/Driver/Happstack/Docs.hs
@@ -5,15 +5,21 @@ import Control.Monad
 import Control.Monad.Trans
 import Happstack.Server
 import Rest.Api
+
 import Rest.Gen.Base
 import Rest.Gen.Docs
 
 -- | Web interface for documentation
 apiDocsHandler :: (ServerMonad m, MonadPlus m, FilterMonad Response m, MonadIO m) => String -> String -> Api a -> m Response
-apiDocsHandler rootURL tmpls api =
-  let mkCtx v ct = DocsContext (rootURL ++ ct ++ "/") v tmpls
-      serve ctx = serveDocs ctx . sortTree . noPrivate . (\(Some1 r) -> apiSubtrees r)
-  in path $ \i -> withVersion i api mzero $ \v -> serve (mkCtx v i)
+apiDocsHandler rootURL tmpls api = path $ \i -> withVersion i api mzero $ \v -> serve (mkCtx v i)
+  where
+    mkCtx :: Version -> String -> DocsContext
+    mkCtx v ct = DocsContext
+      { rootUrl         = rootURL ++ ct ++ "/"
+      , contextVersion  = v
+      , templates       = tmpls
+      }
+    serve ctx = serveDocs ctx . sortTree . noPrivate . (\(Some1 r) -> apiSubtrees r)
 
 serveDocs :: (ServerMonad m, MonadPlus m, FilterMonad Response m, MonadIO m) => DocsContext -> ApiResource -> m Response
 serveDocs ctx tree =

--- a/rest-happstack/src/Rest/Driver/Happstack/Docs.hs
+++ b/rest-happstack/src/Rest/Driver/Happstack/Docs.hs
@@ -5,21 +5,15 @@ import Control.Monad
 import Control.Monad.Trans
 import Happstack.Server
 import Rest.Api
-
 import Rest.Gen.Base
 import Rest.Gen.Docs
 
 -- | Web interface for documentation
 apiDocsHandler :: (ServerMonad m, MonadPlus m, FilterMonad Response m, MonadIO m) => String -> String -> Api a -> m Response
-apiDocsHandler rootURL tmpls api = path $ \i -> withVersion i api mzero $ \v -> serve (mkCtx v i)
-  where
-    mkCtx :: Version -> String -> DocsContext
-    mkCtx v ct = DocsContext
-      { rootUrl         = rootURL ++ ct ++ "/"
-      , contextVersion  = v
-      , templates       = tmpls
-      }
-    serve ctx = serveDocs ctx . sortTree . noPrivate . (\(Some1 r) -> apiSubtrees r)
+apiDocsHandler rootURL tmpls api =
+  let mkCtx v ct = DocsContext (rootURL ++ ct ++ "/") v tmpls
+      serve ctx = serveDocs ctx . sortTree . noPrivate . (\(Some1 r) -> apiSubtrees r)
+  in path $ \i -> withVersion i api mzero $ \v -> serve (mkCtx v i)
 
 serveDocs :: (ServerMonad m, MonadPlus m, FilterMonad Response m, MonadIO m) => DocsContext -> ApiResource -> m Response
 serveDocs ctx tree =


### PR DESCRIPTION
- Use `application/json` instead of `text/json` everywhere
- Adds a `runGenerate` function that doesn't call exitFailure/exitSuccess so generate can be used as part of other executables
- Add separate calls for each generation target inside `Rest.Gen` for library usage
- Adds a `(FileType -> String -> IO String)` argument that can be used for postprocessing output. e.g. to prettify haskell sources or minimize javascript.

This code was pretty messy and I tried to clean it up a bit while I was at it, comments on the API welcome.

@octopuscabbage does this work the way you need it to?

Related: #116, #126, #122
