### PR TITLE
Make Params Applicative

### DIFF
--- a/rest-core/src/Rest/Driver/Perform.hs
+++ b/rest-core/src/Rest/Driver/Perform.hs
@@ -5,6 +5,7 @@
   , OverloadedStrings
   , RankNTypes
   , ScopedTypeVariables
+  , TupleSections
   #-}
 #if MIN_VERSION_base(4,9,0)
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
@@ -205,10 +206,10 @@ headers (TwoHeaders h1 h2) = (,) <$> headers h1 <*> headers h2
 
 parameters :: Rest m => Param p -> ExceptT DataError m p
 parameters p = do
-  ps <- lift $ mapM getPar (paramNames p)
-  mapExceptT (runReader $ catMaybes ps) (paramParser p)
+  ps <- lift $ mapM getPar (paramKeyNames p)
+  mapExceptT (\x -> return $ runReader x $ catMaybes ps) (paramParser p)
   where
-    getPar s = getParameter s >>= \x -> return . return . (s,)
+    getPar s = getParameter s >>= return . fmap (s,)
   
 parser :: Monad m => Format -> Inputs j -> B.ByteString -> ExceptT DataError m (FromMaybe () j)
 parser NoFormat None       _ = return ()

--- a/rest-core/src/Rest/Handler.hs
+++ b/rest-core/src/Rest/Handler.hs
@@ -41,13 +41,11 @@ module Rest.Handler
 
 import Prelude.Compat
 
-import Control.Arrow
 import Control.Monad.Except ()
 import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.Trans.Except
 import Rest.Types.Range
-import Safe
 
 import Rest.Dictionary
 import Rest.Error
@@ -124,7 +122,7 @@ mkListing d a = mkGenHandler (mkPar range . d) (a . param)
 -- parameters, @offset@ and @count@. If not passed, the defaults are 0
 -- and 100. The maximum range that can be passed is 1000.
 
-range :: ParamM Range
+range :: Param Range
 range = Range
   <$> (max 0 <$> (withParamDefault "offset" 0))
   <*> ((min 1000 . max 0) <$> (withParamDefault "count" 100))
@@ -141,12 +139,11 @@ mkOrderedListing d a = mkGenHandler (mkPar orderedRange . d) (a . param)
 -- | Dictionary for taking ordering information. In addition to the
 -- parameters accepted by 'range', this accepts @order@ and
 -- @direction@.
-orderedRange :: ParamM (Range, Maybe String, Maybe String)
-orderedRange = do
-  r <- range
-  mo <- withParamParserDefault "order" Nothing Just
-  mo <- withParamParserDefault "direction" Nothing Just
-  return (r, mo, md)
+orderedRange :: Param (Range, Maybe String, Maybe String)
+orderedRange = (,,)
+  <$> range
+  <*> (withParamParserDefault "order" Nothing Just)
+  <*> (withParamParserDefault "direction" Nothing Just)
 
 -- | Create a handler for a single resource. Takes the entire
 -- environmend as input.

--- a/rest-example/example-api/Api/Test.hs
+++ b/rest-example/example-api/Api/Test.hs
@@ -129,10 +129,13 @@ rawJsonAndXmlO_ = mkHandler (addHeader contentType . mkHeader accept . mkPar typ
         else if XmlFormat `elem` accs
           then return "<xml/>"
           else throwError . OutputError $ UnsupportedFormat "Only json and xml accept headers are allowed"
+
     contentType :: Header (Maybe String)
     contentType  = Header ["Content-Type"] (return . headMay . catMaybes)
+    
     typeParam   :: Param (Maybe String)
-    typeParam    = Param ["type"] (return . headMay . catMaybes)
+    typeParam    = withParamParserDefault "type" Nothing Just 
+
     accept      :: Header (Maybe String)
     accept       = Header ["Accept"] (return . headMay . catMaybes)
 

--- a/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
+++ b/rest-gen/src/Rest/Gen/Base/ActionInfo.hs
@@ -417,9 +417,7 @@ paramNames :: Param a -> [String]
 paramNames = nub . paramNames_
 
 paramNames_ :: Param a -> [String]
-paramNames_ NoParam = []
 paramNames_ (Param s _) = s
-paramNames_ (TwoParams p1 p2) = paramNames p1 ++ paramNames p2
 
 -- | Extract input description from handlers
 handlerInputs :: Handler m -> [DataDescription]


### PR DESCRIPTION
This should resolve #69 I've made params applicative which greatly simplifies the definitions of range and (IMHO) gives much more flexibility to this library. 

NOTE: This pattern can also be applied to `Header` as it has the same format as `Param`